### PR TITLE
Call the correct execute_command function

### DIFF
--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -33,13 +33,13 @@ M.build_restart = function()
 end
 
 M.compile_cascade = function()
-  M.execute_command({
+  execute_command({
     command = 'metals.compile-cascade';
   })
 end
 
 M.doctor_run = function()
-  M.execute_command({
+  execute_command({
     command = 'metals.doctor-run';
   })
 end


### PR DESCRIPTION
I have no lua experience, so maybe this is not actually the right thing
to do. The current implementation breaks with "attempt to call field"
though, and to me it looks like `execute_command` does not come from
`M`.