### PR TITLE
Did focus provider

### DIFF
--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -227,4 +227,15 @@ M['metals/publishDecorations'] = function(err, _, decorations)
   end
 end
 
+-- Notify the server when document has been focused
+-- This needs to be called in the appropriate autocommand, i.e. FocusGained
+M.did_focus = function()
+  local focused_uri = vim.uri_from_bufnr(0)
+  vim.lsp.buf_request(0, 'metals/didFocusTextDocument', focused_uri, function(err, _, _)
+    if err then
+      print('metals/didFocusTextDocument: Server Error')
+    end
+  end)
+end
+
 return M

--- a/lua/metals/setup.lua
+++ b/lua/metals/setup.lua
@@ -10,4 +10,10 @@ M.on_init = function(client, _)
   client.resolved_capabilities.text_document_save = true
 end
 
+M.auto_commands = function()
+  vim.api.nvim_command [[augroup NvimMetals]]
+    vim.api.nvim_command [[autocmd BufEnter <buffer> lua require'metals'.did_focus()]]
+  vim.api.nvim_command [[augroup end]]
+end
+
 return M

--- a/nvim-lsp.vim
+++ b/nvim-lsp.vim
@@ -48,6 +48,7 @@ let g:metals_decoration_color = 'Conceal'
   M.on_attach = function()
       require'diagnostic'.on_attach()
       require'completion'.on_attach()
+      setup.auto_commands()
     end
 
   nvim_lsp.metals.setup{
@@ -61,6 +62,7 @@ let g:metals_decoration_color = 'Conceal'
       quickPickProvider            = true;
       executeClientCommandProvider = true;
       decorationProvider           = true;
+      didFocusProvider             = true;
     };
 
     on_init = setup.on_init;
@@ -72,8 +74,10 @@ let g:metals_decoration_color = 'Conceal'
       ["metals/quickPick"]            = metals['metals/quickPick'];
       ["metals/executeClientCommand"] = metals["metals/executeClientCommand"];
       ["metals/publishDecorations"]   = metals["metals/publishDecorations"];
+      ["metals/didFocusTextDocument"] = metals["metals/didFocusTextDocument"];
     };
   }
+
 EOF
 
 "-----------------------------------------------------------------------------


### PR DESCRIPTION
This adds did focus but I see metals throwing exceptions when a notification is sent, the server recovers so we can simply remove the error printing in nvim-metals and merge, though at the moment I don't see the focus refresh being useful, when save event works for evaluations. 

It is rebased on top of decoration_provider PR