### PR TITLE
Remove no longer needed on_init hack

### DIFF
--- a/lua/metals/setup.lua
+++ b/lua/metals/setup.lua
@@ -4,12 +4,6 @@
 
 local M = {}
 
---[[ The only way to enable didSave with current LSP and metals
-capabilities is to override after init. --]]
-M.on_init = function(client, _)
-  client.resolved_capabilities.text_document_save = true
-end
-
 M.auto_commands = function()
   vim.api.nvim_command [[augroup NvimMetals]]
     vim.api.nvim_command [[autocmd BufEnter <buffer> lua require'metals'.did_focus()]]

--- a/nvim-lsp.vim
+++ b/nvim-lsp.vim
@@ -65,8 +65,6 @@ let g:metals_decoration_color = 'Conceal'
       didFocusProvider             = true;
     };
 
-    on_init = setup.on_init;
-
     callbacks = {
       ["textDocument/hover"]          = metals['textDocument/hover'];
       ["metals/status"]               = metals['metals/status'];


### PR DESCRIPTION
Since https://github.com/scalameta/metals/pull/1837 we no
longer need to do the on_init hack since we explicitly
say to clients that we want on save events.