### PR TITLE
MVP for showing all LSP buffer diagnostics in the quickfix

### DIFF
--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -12,8 +12,9 @@ CONTENTS                                                           *nvim-metals*
     2. Commands.............. |metals-commands|
     3. LUA API............... |metals-lua-api|
     4. DECORATION API........ |metals-decoration-api|
-    5. Custom Callbacks...... |metals-custom-callbacks|
-    6. Functions............. |metals-functions|
+    5. DIAGNOSTIC API........ |metals-decoration-api|
+    6. Custom Callbacks...... |metals-custom-callbacks|
+    7. Functions............. |metals-functions|
 
 ================================================================================
 INTRODUCTION                                                *metals-introdction*
@@ -159,6 +160,18 @@ protocol related things.
                                                           *show_hover_message()*
 show_hover_message()     Use to expand the decoration to show the full hover
                          message that was returned from the decoration.
+
+================================================================================
+DIAGNOSTIC API                                           *metals-decoration-api*
+
+Functions related to LSP diagnostics received via `textDocument/publishDiagnostics`
+
+open_all_diagnostics()   Fills the quickfix list with the LSP diagnostics
+                         for all buffers and opens it.
+                         WARNING: Automatic updates in the quickfix for new
+                         diagnostics are not yet implemented.
+                         After opening the quickfix, in order to refesh diagnostics
+                         the function must be called again.
 
 ================================================================================
 CUSTOM CALLBACKS                                       *metals-custom-callbacks*

--- a/lua/metals/diagnostic.lua
+++ b/lua/metals/diagnostic.lua
@@ -1,0 +1,41 @@
+local api = vim.api
+local lsp = require'vim.lsp'
+
+local M = {}
+
+--[[
+  Fills the quick-fix with all the current LSP buffer diagnostics and opens it
+  WARNING: The diagnostic quickfix list WILL ONLY be refreshed when this function is called,
+    as opposed to diagnostic-nvim controlled location lists that gets updated in real time.
+--]]
+M.open_all_diagnostics = function()
+  lsp.util.set_qflist(M.get_all_lsp_diagnostics_as_qfitems())
+  api.nvim_command("copen")
+  api.nvim_command("wincmd p")
+end
+
+-- Collects all LSP buffer diagnostic lists and flattens them into a quick-fix item list
+M.get_all_lsp_diagnostics_as_qfitems = function()
+  local qfitems = {}
+  for bufnr, diagnostics in pairs(lsp.util.diagnostics_by_buf) do
+    local uri = vim.uri_from_bufnr(bufnr)
+    for _, d in ipairs(diagnostics) do
+      local item = {
+        bufrn = bufnr,
+        filename = vim.uri_to_fname(uri),
+        text  = d.message,
+        lnum  = d.range.start.line + 1,
+        col   = d.range.start.character + 1
+      }
+      if d.severity == 1 then
+        item.type = 'E'
+      elseif d.severity == 2 then
+        item.type = 'W'
+      end
+      table.insert(qfitems, item)
+    end
+  end
+  return qfitems
+end
+
+return M


### PR DESCRIPTION
This is a working first stab at the problem of workspace wide diagnostics in nvim-metals.
The very simple approach is to fill the quickfix-list with the LSP diagnostics for all the buffers.
It has the issue of updating it with newer diagnostics, to refresh we need to call the function again,
mapped as OpenAllDiagnostics.

As diagnostics are published per file, and not batched in a compilation, refreshing when we get a LspDiagnosticsRefresh event is probably too noisy and can be too disruptive when we are doing other things with the quickfix, e.g. going through grep.

We could think about only refreshing when the quickfix is open and keep an lsp diagnostic change ticket to check when the refresh gets called automatically. Also, we could enable some filtering to only show bloop diagnostics, options to filter out warnings, etc. 

Nevertheless I think it's worth to start simple and this mechanism works well as it is in this PR. I needed something to refactor a big codebase and with this simple function it's a pleasure having all the errors from bloop in the quickfix-list, navigating them, using :cdo, etc.

Even thought it might not be the final solution, just as it is now improves the productivity of nvim-metals massively and makes it a viable alternative to coc. I use nvim-metals now for my commercial scala development.
