### PR TITLE
Implement basic `window/showMessageRequest`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,12 +210,3 @@ the below example or added into an existing statusline integration:
 set statusline+=%{metals#status()}
 ...
 ```
-
-## Importing your build
-
-**You need to do this before any Metals functionality will work**
-
-Since `window/showMessageRequest` is not yet supported in the Nvim LSP module,
-you need to trigger this manually. As you would normally, open your project and
-then issue a `:MetalsBuildImport` command which will send the request to Metals to
-import your build.

--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -251,16 +251,6 @@ The following are extra handlers that nvim-metals implements. More than likely
 you'll never directly use these, but they are more of a reference of the extra
 things that nvim-metals is providing you.
 
-                                                        *['textDocument/hover']*
-['textDocument/hover']({err}, {method}, {result})
-                          Used to override the default ["textDocument/hover"]
-                          callback since the default doesn't wrap lines.
-
-                          Parameters:
-                          {err}    Hover error
-                          {method} textDocument/hover
-                          {result} hover results from the server
-
                                                              *['metals/status']*
 ['metals/status']({err}, {method}, {result})
                           Used to enable handling of |metals/status|
@@ -314,6 +304,29 @@ The spec for this can be found here:
 
 https://scalameta.org/metals/docs/editors/new-editor.html#metalsexecuteclientcommand
 
+                                                        *['textDocument/hover']*
+['textDocument/hover']({err}, {method}, {result})
+                          Used to override the default ["textDocument/hover"]
+                          callback since the default doesn't wrap lines.
+
+                          Parameters:
+                          {err}    Hover error
+                          {method} textDocument/hover
+                          {result} hover results from the server
+
+                                                 *['window/showMessageRequest']*
+
+['window/showMessageRequest']({err}, {method}, {result})
+                          Used to request an answer from the user.
+
+                          Note that this is only in here temporarily. Once
+                          this is solidified we should try to just upstream
+                          it.
+
+                          Parameters:
+                          {err}    Message request error
+                          {method} window/showMessageRequest
+                          {result} ShowMessageRequestParams 
 ================================================================================
 FUNCTIONS                                                     *metals-functions*
 

--- a/lua/metals/setup.lua
+++ b/lua/metals/setup.lua
@@ -139,6 +139,9 @@ M.initialize_or_attach = function(config)
   config.handlers['metals/publishDecorations'] = config.handlers['metals/publishDecorations'] or
                                                      handlers['metals/publishDecorations']
 
+  config.handlers['window/showMessageRequest'] = config.handlers['window/showMessageRequest'] or
+                                                     handlers['window/showMessageRequest']
+
   config.capabilities = config.capabilities or lsp.protocol.make_client_capabilities()
 
   config.init_options = config.init_options or {}

--- a/lua/metals/util.lua
+++ b/lua/metals/util.lua
@@ -160,15 +160,6 @@ M.wrap_hover = function(bufnr, winnr)
   end
 end
 
----- UI. Probably this should be a separate ui.lua module if this grows.
-M.input_box = function(prompt)
-  return vim.fn.input(prompt)
-end
-
-M.input_list = function(options)
-  return vim.fn.inputlist(options)
-end
-
 --[[
  Checks to see if an executable is present for single or list of executables
  Note that give a list, if any is not found, this will return false Also, this


### PR DESCRIPTION
Since this isn't part of the upstream LSP implementation yet (see here: https://github.com/neovim/neovim/issues/11710), I figured I'd give this a shot with just adding it in here first. If this seems to work well I'll try to upstream this. This is quite important to have since Metals makes heavy use of this.