### PR TITLE
Remove showMessageRequest.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ more feature-full and stable Metals + Nvim experience.
     [here](https://github.com/neovim/neovim/wiki/Installing-Neovim). It's best to
     re-build often as LSP support is changing daily. The easiest way to ensure
     you're on nightly is to to do a `nvim --version`. If you see anything `v0.4.x`
-    then it didn't work. You're looking for `v0.5.x`:
+    then it didn't work. You're looking for `v0.5.x`. _NOTE_: Make sure the
+    version you're using includes commit #fa25694.
 - Ensure [Coursier](https://get-coursier.io/docs/cli-installation) is installed
     on your machine. nvim-metals uses Coursier to download and update Metals.
 - Remove `F` from `shortmess`. `set shortmess-=F` _NOTE_: Without doing this,

--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -31,7 +31,8 @@ the correct `init_options`.
 PREREQUISITES                                             *metals-prerequisites*
 
 - Nvim v0.5.x The later the snapshot the better unitl v0.5.x stable is
-  released.
+  released. _NOTE_: Make sure the version you're using includes commit
+  #fa25694.
 - *DO NOT* use this plugin for Metals and also nvim/nvim-lspconfig for Metals.
   If you've used this plugin before with Metals, make sure to remove the
   Metals installation that it installed. If you have that plugin installed,
@@ -516,19 +517,6 @@ https://scalameta.org/metals/docs/editors/new-editor.html#metalsexecuteclientcom
                           {method} textDocument/hover
                           {result} hover results from the server
 
-                                                 *['window/showMessageRequest']*
-
-['window/showMessageRequest']({err}, {method}, {result})
-                          Used to request an answer from the user.
-
-                          Note that this is only in here temporarily. Once
-                          this is solidified we should try to just upstream
-                          it.
-
-                          Parameters:
-                          {err}    Message request error
-                          {method} window/showMessageRequest
-                          {result} ShowMessageRequestParams 
 ================================================================================
 FUNCTIONS                                                     *metals-functions*
 

--- a/lua/metals/handlers.lua
+++ b/lua/metals/handlers.lua
@@ -8,33 +8,6 @@ local M = {}
 local decoration_namespace = api.nvim_create_namespace('metals_decoration');
 
 --[[
-A simple implementation of `window/showMessageRequest` until this gets added
-upstream. Note that is is very similiar to how we handle `metals/quickPick`
-TODO: Ensure that this coveres various scenarios correctly and then see if we
-can ustream this when we're confident it's working.
-https://github.com/neovim/neovim/issues/11710
-]]
-M['window/showMessageRequest'] = function(_, _, res)
-  local titles = {}
-  local labels = {}
-
-  table.insert(labels, res.message .. ':')
-
-  for i, item in pairs(res.actions) do
-    table.insert(titles, item.title)
-    table.insert(labels, i .. ' - ' .. item.title)
-  end
-
-  local choice = vim.fn.inputlist(labels)
-  if (choice == 0) then
-    print('\nmetals: operation cancelled')
-    return {cancelled = true}
-  else
-    return {title = titles[choice]}
-  end
-end
-
---[[
 Implementation of the `metals/quickPick` Metals LSP extension.
 https://scalameta.org/metals/docs/integrations/new-editor.html#metalsquickpick
 ]]


### PR DESCRIPTION
As of https://github.com/neovim/neovim/pull/13641 this is now
in neovim core. So there is no need for the custom one that we
have in here anymore.