### PR TITLE
Trim down readme and point to help docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![nvim-metals logo](https://i.imgur.com/7gqEQOi.png)
+
 # nvim-metals
 
 nvim-metals is a Lua plugin built to provide a better experience while using
@@ -10,27 +11,22 @@ much richer experience than just using Metals with the default
 [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) setup, as well as
 automatically setting all of the correct `init_options`.
 
-_NOTE:_ Keep in mind that the level of support is rapidly changing, there are
-bugs, missing features, and some of this is is changing daily,
-*so expect stuff to break without warning or change* until this is removed.
+_NOTE:_ Keep in mind that the level of support is rapidly changing, so expect
+stuff to break without warning or change until this is removed.
 
-If you're first getting starting with Metals, consider using
-[coc-metals](https://github.com/scalameta/coc-metals) if you're looking for a
-more feature-full and stable Metals + Nvim experience.
-
-## Table of Contents
-  - [Prerequisites](#prerequisites)
-  - [Installation](#installation)
-  - [Getting Started](#getting-started)
-  - [Settings and Mappings](#settings-and-mappings)
-  - [Available Commands and Options](#available-commands-and-options)
-  - [Metals Handlers](#metals-handlers)
-  - [Statusline Integration](#statusline-integration)
+<p align="center">
+    <a href="https://gitter.im/scalameta/metals-vim">
+        <img alt="link to gitter" src="https://img.shields.io/gitter/room/scalameta/metals-vim?style=flat-square">
+    </a>
+    <a href="https://github.com/scalameta/nvim-metals/blob/master/doc/metals.txt">
+        <img alt="link to help docs" src="https://img.shields.io/badge/docs-%3Ah%20nvim--metals-blue?style=flat-square">
+    </a>
+</p>
 
 ## Prerequisites
 
 - Before you get started you need to ensure that you have the nightly/development
-    build of Nvim. LSP support hasn't landed in stable yet. You can find
+    build of Neovim. LSP support hasn't landed in stable yet. You can find
     instructions for how to do this for your OS
     [here](https://github.com/neovim/neovim/wiki/Installing-Neovim). It's best to
     re-build often as LSP support is changing daily. The easiest way to ensure
@@ -39,16 +35,15 @@ more feature-full and stable Metals + Nvim experience.
     version you're using includes commit #6e660d4 to ensure
     `window/showMessageRequest`s work.
 - Ensure [Coursier](https://get-coursier.io/docs/cli-installation) is installed
-    on your machine. nvim-metals uses Coursier to download and update Metals.
+    on your machine. `nvim-metals` uses Coursier to download and update Metals.
 - Remove `F` from `shortmess`. `set shortmess-=F` _NOTE_: Without doing this,
     autocommands that deal with filetypes prohibit messages from being shown...
     and since we heavily rely on this, this _must_ be set.
-
-```vim
-❯ nvim --version
-NVIM v0.5.0-3de9452
-...
-```
+- Ensure that you have mappings created for functionality that you desire. By
+    default methods for things like goto definition, find references, etc are
+    there, but not automatically mapped. You can find both minimal mixed
+    Vimscript/Lua and pure Lua example configurations for `nvim-metals`
+    [here](https://github.com/scalameta/nvim-metals/discussions/39).
 
 ## Installation
 
@@ -59,169 +54,23 @@ have Metals configured through `nvim-lspconfig` while using this plugin. If you
 have `nvim/lsp-config` registered with `nvim-lspconfig`, you'll want to remove
 it.
 
-Use whichever plugin manager you prefer to install this. Here is an example for
-[vim-plug](https://github.com/junegunn/vim-plug):
+`nvim-metals` is just a plugin installed like any other Neovim plugin. For
+example if using [`packer`](https://github.com/wbthomason/packer.nvim):
 
-```vim
-Plug 'scalameta/nvim-metals'
+```lua
+use 'scalameta/nvim-metals'
 ```
 
 ## Getting started
 
-nvim-metals is triggered by an auto command to start on and Scala files. The
-following is the most basic setup to get started:
+To get started with `nvim-metals`, please read `:help nvim-metals`.
 
-```vim
-if has('nvim-0.5')
-  augroup lsp
-    au!
-    au FileType scala,sbt lua require('metals').initialize_or_attach({})
-  augroup end
-endif
-```
+## Settings, Commands, and Options
 
-Once you open a Scala file, you'll be prompted to install metals. You can do
-this with the following command:
+To view all of the available commands, check out `:help metals-commands` in the
+help docs. Similarly, to see the available configuration options, check out
+`:help metals-options`, and `:help metals-settings` for settings.
 
-```vim
-:MetalsInstall
-```
-
-This will install the `latest.stable` of Metals, but if you'd like to use a
-snapshot, you can set it like so:
-
-```vim
-let g:metals_server_version = '0.9.7+18-744ffa6f-SNAPSHOT'
-```
-
-_NOTE_: If you didn't see a prompt to install metals, make sure you have the
-following set and try again.
-
-```vim
-set shortmess-=F
-```
-
-Keep in mind that when a new version of Metals comes out or when you change this
-value, you'll need to just run `:MetalsInstall` again to update. If you want to
-know what version of Metals you're using, you can use the `:MetalsInfo` command.
-
-If you'd like a more advanced setup, the `{}` that you pass into
-`initialize_or_attach()` is very similar to the config object that gets passed
-to `vim.lsp.start_client()`, so you have full access to edit anything to start
-the server in addition to also being able to set Metals settings. If you're not
-just going to pass in `{}` require a bare config which gives you the basic table
-shape you'll need. To give an example of this, below is an example setup in order
-to register [completion-nvim](https://github.com/nvim-lua/completion-nvim) for
-better completions, set the `statusBarProvider` to `'on'` instead of
-`'show-message'`, to update the way `publishDiagnostics` work to include a
-fancier prefix, and to set a few available Metals settings.
-
-```lua
-metals_config = require'metals'.bare_config
-metals_config.settings = {
-  showImplicitArguments = true,
-  excludePackages = {
-    "akka.actor.typed.javadsl",
-    "com.github.swagger.akka.javadsl"
-  }
-}
-
-metals_config.on_attach = function()
-  require'completion'.on_attach();
-end
-
-metals_config.init_options.statusBarProvider = 'on'
-
-metals_config.handlers["textDocument/publishDiagnostics"] = vim.lsp.with(
-  vim.lsp.diagnostic.on_publish_diagnostics, {
-    virtual_text = {
-      prefix = '',
-    }
-  }
-)
-```
-
-## Settings and Mappings
-
-The nvim LSP implementation comes with a rich Lua API, but you need to set up
-your mappings yourself. For example, here are some mappings to get you started,
-but you should feel free to change them to your liking:
-
-```vim
-nnoremap <silent> gd          <cmd>lua vim.lsp.buf.definition()<CR>
-nnoremap <silent> K           <cmd>lua vim.lsp.buf.hover()<CR>
-nnoremap <silent> gi          <cmd>lua vim.lsp.buf.implementation()<CR>
-nnoremap <silent> gr          <cmd>lua require'telescope.builtin'.lsp_references{}<CR>
-nnoremap <silent> <leader>s   <cmd>lua require'telescope.builtin'.lsp_workspace_symbols{}<CR> 
-nnoremap <silent> gds         <cmd>lua vim.lsp.buf.document_symbol()<CR>
-nnoremap <silent> gws         <cmd>lua vim.lsp.buf.workspace_symbol()<CR>
-nnoremap <silent> <leader>rn  <cmd>lua vim.lsp.buf.rename()<CR>
-nnoremap <silent> <leader>f   <cmd>lua vim.lsp.buf.formatting()<CR>
-nnoremap <silent> <leader>ca  <cmd>lua vim.lsp.buf.code_action()<CR>
-nnoremap <silent> <leader>ws  <cmd>lua require'metals'.worksheet_hover()<CR>
-nnoremap <silent> <leader>a   <cmd>lua require'metals'.open_all_diagnostics()<CR>
-```
-
-You can also map any of the functions from the nvim-metals api as well. You can
-see all the options in `:h metals-lua-api`. Here is an example of mapping the
-`build-import` command:
-
-```vim
-nnoremap <silent> <leader>bi  <cmd>lua require'metals'.build_import()<CR>
-```
-
-Or in Lua
-
-```lua
-vim.api.nvim_set_key('n', '<leader>bi', '<cmd>lua require'metals'.build_import()<CR>', {noremap = true})
-```
-
-This would allow you to do `<leader>bi` to trigger an import, the same way
-`:MetalsBuildImport` does.
-
-_NOTE_: You can find a full example of a configuration
+_NOTE_: You can find an example of a minimal configuration showing how to set
+various settings and options
 [here](https://github.com/scalameta/nvim-metals/discussions/39).
-
-## Available Commands and Options
-
-To view all of the available commands, check out `:h metals-commands` in the
-help docs. Similarly, to see the available configuration options, check out `:h
-metals-options`, and for settings, `:h metals-settings`.
-
-## Metals Handlers
-
-The nvim LSP integration relies on a series of handlers to handle various LSP
-methods. This is also the way custom LSP extensions can be handled. Metals
-implements a fair amount of these, and you can see all of the custom handlers
-that nvim-metals adds by viewing them in the help docs: `:h
-metals-custom-handlers`.
-
-## Statusline integration
-
-nvim-metals provides a few functions that can be used in your statusline in
-order to show Errors, Warnings, and Metals status. For diagnostics you can use
-them like below:
-
-```vim
-...
-set statusline+=%{metals#errors()}
-set statusline+=%{metals#warnings()}
-...
-```
-
-![Statusline](https://i.imgur.com/y4hij0S.png)
-
-The colors are using a custom highlighting group that you'd need to define or
-assign yourself.
-
-You can also enable
-[`metals/status`](https://scalameta.org/metals/docs/editors/new-editor.html#metalsstatus)
-which will allow for you to use the `metals#status()` function in your
-statusline to show the status messages coming from Metals. This can be used like
-the below example or added into an existing statusline integration:
-
-```vim
-...
-set statusline+=%{metals#status()}
-...
-```

--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -38,6 +38,11 @@ PREREQUISITES                                             *metals-prerequisites*
   to remove metals setup for it as it and this plugin will conflict.  NOTE:
   that keeping the plugin installed for other LSP servers is totally fine,
   just let nvim-metals handle Metals.
+- https://get-coursier.io/ - Metals uses coursier to manage the installation
+  and updatign of Metals.
+- Make sure you have your mappings for various LSP functionality configure.
+  Neovim provides functions for things like goto-definition, find references,
+  etc, but they need to be mapped.
 
 ================================================================================
 GETTING STARTED                                         *metals-getting-started*
@@ -56,7 +61,7 @@ This will give you the the defaults that Metals provides. The empty `{}` that
 is passed into |initialize_or_attach()| is necessary and is very similiar to
 the config object that is directly passed into the |vim.lsp.start_client()|
 method. The only differences is the addition of settings and root_patterns.
-You can read more about it in |:h vim.lsp.start_client()| to see all of the
+You can read more about it in |vim.lsp.start_client()| to see all of the
 base options. This is is the primary way to edit your `init_option`, change or
 add any cusom `handlers`, and set any configurartion settings. For example,
 it's recommened to set your `statusBarProvider` to `on`, and once you have
@@ -70,7 +75,7 @@ Then instead of passing an empty `{}` to |initialize_or_attach()|,  you'd pass
 in `metals_config`.
 
 Once setup, the first time you open a Scala project you'll be prompted to
-install Metals. You can do this with the following command: |:MetalsInstall|.
+install Metals. You can do this with the following command: |MetalsInstall|.
 
 In order to install the latest snapshot of metals, you'll need to have set the
 following: >
@@ -79,16 +84,19 @@ following: >
 <
 
 If no version is set, it defaults to the latest stable release. If a new
-release comes out or you change your |g:metals_server_version|,  you can
-simply issue another |:MetalsInstall| command which also serves as an update
+release comes out or you change your |g:metals_server_version|, you can
+simply issue another |MetalsInstall| command which also serves as an update
 command.
 
+If you believe that you have everything configured correctly, but do not see
+the message about installing Metals, ensure that you have removed `F` from
+`shortmess`. The you should be able to execute a |MetalsInfo| to see the
+installed Metals version.
 ================================================================================
 SETTINGS                                                       *metals-settings*
 
 The following settings are able to be passed along with the config table to
-|initialize_or_attatch()|. The keys are check to ensure that you don't pass in
-a setting that is not a valid Metals setting. You can set these like the
+|initialize_or_attatch()|. The keys are check to ensure that you don't pass in a setting that is not a valid Metals setting. You can set these like the
 example below shows: >
 
   metals_config = require'metals'.bare_config
@@ -602,6 +610,9 @@ https://scalameta.org/metals/docs/editors/new-editor.html#metalsexecuteclientcom
 
 ================================================================================
 FUNCTIONS                                                     *metals-functions*
+
+nvim-metals provides a few functions that can be used in your statusline in
+order to show Errors, Warnings, and Metals status.
 
                                                                *metals#status()*
 metals#status()           Able to be used in your statusline to show status


### PR DESCRIPTION
One thing I did wrong with coc-metals was duplicate the stuff
I put on the website and in the readme. I don't want to make that
mistake again with having docs in various places. In this commit
I slim down the readme and point people to the help docs and also
to the example configuration in the discussions. I would like to
keep the readme as thin as possible while keeping the help docs
as rich as possible and the center of truth. This will bring the
most benifit since you can both view them on github and also
while in neovim.