### PR TITLE
Set buffer-local variable to identify metals logs buffer

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -2,10 +2,8 @@
 
 max_line_length = 100 
 globals = {
-  "Coursier_handle"
-}
-read_globals = {
-  "vim",
+  "Coursier_handle",
+  "vim"
 }
 exclude_files = {
   "lua/metals/log.lua"


### PR DESCRIPTION
Fixes #87 

~I haven't installed everything from CONTRIBUTING.md, just~ want to check if approach makes sense :) 

I'm doing it this way because I couldn't find an API that parses `term://{cwd}//{pid}:{cmd}` format that is in buffer name for terminals.

If there's such an API (and if it's preferable to use it), let me know @ckipp01 