### PR TITLE
Add in a g:metals_use_global_executable option.

### DIFF
--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -350,6 +350,17 @@ The hightlight group that will be used to show decorations. For example, this
 will change the way worksheet evaluations are displayed in `*.worksheet.sc`
 file.
 
+                                                *g:metals_use_global_executable*
+Type: boolean ~
+Default: false ~
+
+For all you crazy Nix kids out there, or if you are want to re-use the same
+executable for multiple clients, this is for you. Please NOTE that by doing
+this, you are fully taking control of updating and installing Metals. Unless
+there is a specific reason that you want to manage your own version and install
+manually, then I'd recommend not using this setting and just letting nvim-metals
+handle it.
+
 ================================================================================
 COMMANDS                                                       *metals-commands*
 

--- a/lua/metals/health.lua
+++ b/lua/metals/health.lua
@@ -1,6 +1,7 @@
 local uv = vim.loop
 local setup = require 'metals.setup'
 local messages = require 'metals.messages'
+local util = require 'metels.util'
 
 local health_start = vim.fn['health#report_start']
 local health_ok = vim.fn['health#report_ok']
@@ -26,10 +27,10 @@ M.checkHealth = function()
     health_error(messages.coursier_not_installed)
   end
 
-  local metals_installed = uv.fs_stat(setup.metals_bin)
+  local metals_installed = util.has_bins(setup.metals_bin())
 
   if metals_installed then
-    local info = vim.fn.system(setup.metals_bin .. ' --version')
+    local info = vim.fn.system(setup.metals_bin() .. ' --version')
     health_ok('Metals found')
     health_info(info)
   else

--- a/lua/metals/messages.lua
+++ b/lua/metals/messages.lua
@@ -19,4 +19,15 @@ You need to install Metals first before using `:MetalsInfo`.
 
 To install, use `:MetalsInstall`]]
 
+M.use_global_set_but_cant_find = [[
+You have `g:metals_use_global_executable` set to true, but nvim-metals is unable
+to find your executable Metals. Make sure `metals` is on your $PATH. If you
+want nvim-metals to install Metals for you, remove the
+`g:metals_use_global_executable` setting.]]
+
+M.use_global_set_so_cant_update = [[
+You have `g:metals_use_global` set to true, so nvim-metals can't install or
+update your Metals executable. If you'd like nvim-metals to handle this for
+you, remove the `g:metals_use_global_executable` setting and try again.]]
+
 return M


### PR DESCRIPTION
Up until this point nvim-metals fully handled the Metals install and
updates, and there was no option to _not_ have it do so. By adding in
this setting users can now just set `g:metals_use_global_executable` to
true, and then nvim-metals will default to using whichever Metals
executable is found on the $PATH.

NOTE: That this isn't really recommended to use as most of the time it's
preferable to just let nvim-metals handle this, but if you're in the
group of Nix users or someone that wants to use the same executable for
multiple different clients, this can be useful to you.