### PR TITLE
Ensure nvim-metals cache dir is created right away.

### DIFF
--- a/lua/metals/log.lua
+++ b/lua/metals/log.lua
@@ -46,6 +46,9 @@ end
 M.nvim_metals_log = util.path.join(util.nvim_metals_cache_dir, 'nvim-metals.log')
 
 local generate_log_functions = function()
+  if not util.path.is_dir(util.nvim_metals_cache_dir) then
+    os.execute('mkdir -p ' .. util.nvim_metals_cache_dir)
+  end
   local log_at_level = function(level, show_user, ...)
     local nameupper = level:upper()
 


### PR DESCRIPTION
If not in the situaton where a user open a Scala project for the very
first time without the cache dir every being created, it will throw a
warning. This is because we are trying to log before we've installed
Metals which is when the cache dir was created before.