### PR TITLE
Pass client and bufnr parameter to user on_attach function

### DIFF
--- a/lua/metals/setup.lua
+++ b/lua/metals/setup.lua
@@ -244,8 +244,8 @@ M.initialize_or_attach = function(config)
     config.on_attach = M.auto_commands
   else
     local user_on_attach = config.on_attach
-    config.on_attach = function()
-      user_on_attach()
+    config.on_attach = function(client, _bufnr)
+      user_on_attach(client, _bufnr)
       M.auto_commands()
     end
   end


### PR DESCRIPTION
If you do `:help lsp.start_client`, you can find the definition of the `on_attach` callback, which takes two parameters. For instance when using `lsp-status`, one need to pass the parameters to `require('lsp-status').on_attach` for it to initialize properly.