### PR TITLE
Disable color output for DAP via init option.

### DIFF
--- a/lua/metals/setup.lua
+++ b/lua/metals/setup.lua
@@ -113,6 +113,7 @@ local metals_init_options = {
   compilerOptions = {snippetAutoIndent = false},
   decorationProvider = true,
   didFocusProvider = true,
+  disableColorOutput = true,
   doctorProvider = 'json',
   executeClientCommandProvider = true,
   inputBoxProvider = true,


### PR DESCRIPTION
As a follow-up to https://github.com/scalameta/metals/pull/2615, color
can now be disabled for DAP communication to avoid all the color codes
that were showing up both for Bloop and sbt.

Closes #107