### PR TITLE
Update to _trim.

### DIFF
--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -136,7 +136,7 @@ M.info = function()
     table.insert(output, "  - https://github.com/scalameta/nvim-metals")
     table.insert(output, "  - https://github.com/scalameta/metals")
 
-    output = lsp.util._trim_and_pad(output, { pad_left = 2, pad_top = 1 })
+    output = lsp.util._trim(output)
     local win_id = ui.make_float_with_borders(output, "nvim-metals")
     lsp.util.close_preview_autocmd({ "BufHidden", "BufLeave" }, win_id)
   end


### PR DESCRIPTION
The latest nvim snapshot got rid of _trim_and_pad and replaced it with _trim.
Users will need to update to the latest snapshot.