### PR TITLE
Add in ability to restart server.

### DIFF
--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -389,7 +389,9 @@ The following commands are provided by nvim-metals:
   * |MetalsOrganizeImports|
   * |MetalsQuickWorksheet|
   * |MetalsResetChoice|
+  * |MetalsRestartServer|
   * |MetalsSourcesScan|
+  * |MetalsStartServer|
 
                                                                         *Format*
 Format                       Format the current buffer utilizing. (Make sure to
@@ -505,8 +507,15 @@ MetalsResetChoice            ResetChoicePopup command allows you to reset a
                              E.g. If you choose to import workspace with sbt you
                              can decide to reset and change it again.
 
+                                                           *MetalsRestartServer*
+MetalsRestartServer          Restart the Metals server.
+
                                                              *MetalsSourcesScan*
 MetalsSourcesScan            Scan all workspaces sources.
+
+                                                             *MetalsStartServer*
+MetalsStartServer           Start Metals server. Must be in a Scala or sbt file
+                            in a workspace where Metals is not yet started.
 
 ================================================================================
 LUA API                                                         *metals-lua-api*
@@ -676,8 +685,15 @@ organize_imports()       Use a code action request get edits from Metals to
                                                                 *reset_choice()*
 reset_choice()           Use to execute a |metals.reset-choice| command.
 
+                                                              *restart_server()*
+restart_server()         Restart the Metals server.
+
                                                                 *sources_scan()*
 sources_scan()           Use to execute a |metals.sources-scan| command.
+
+                                                                *start_server()*
+start_server()           Start Metals server. Must be in a Scala or sbt file in
+                         a workspace where Metals is not yet started.
 
                                                              *worksheet_hover()*
 worksheet_hover()        Use to expand the decoration to show the full hover

--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -239,6 +239,30 @@ M.organize_imports = function()
   end
 end
 
+-- Used to fully restart Metals. This will send a shutdown request to Metals,
+-- delay for 3 seconds, and then reconnect.
+M.restart_server = function()
+  for _, buf in pairs(vim.fn.getbufinfo({ bufloaded = true })) do
+    if vim.tbl_contains(setup.scala_file_types, api.nvim_buf_get_option(buf.bufnr, "filetype")) then
+      local clients = lsp.buf_get_clients(buf.bufnr)
+      for _, client in ipairs(clients) do
+        if client.config.name == "metals" then
+          client.stop()
+        end
+      end
+    end
+  end
+
+  vim.defer_fn(function()
+    setup.reset_lsps()
+    setup.initialize_or_attach(setup.config)
+  end, 3000)
+end
+
+M.start_server = function()
+  setup.initialize_or_attach(setup.config)
+end
+
 -- Since we want metals to be the entrypoint for everything, just for ensure that it's
 -- easy to set anything for users, we simply include them in here and then expose them.
 M.bare_config = setup.bare_config

--- a/plugin/metals.vim
+++ b/plugin/metals.vim
@@ -25,7 +25,9 @@ command! MetalsNewScalaProject lua require'metals'.new_scala_project()
 command! MetalsOrganizeImports lua require'metals'.organize_imports()
 command! MetalsQuickWorksheet lua require'metals'.new_scala_file('file://' .. vim.fn.expand("%:p:h"), vim.fn.expand("%:p:h:t"), 'worksheet')
 command! MetalsResetChoice lua require'metals'.reset_choice()
+command! MetalsRestartServer lua require'metals'.restart_server()
 command! MetalsSourcesScan lua require'metals'.sources_scan()
+command! MetalsStartServer lua require'metals'.start_server()
 
 function! metals#status() abort
   return get(g:, 'metals_status', '')


### PR DESCRIPTION
The original idea behind this is for the workflow I have of:
  1. publishing Metals
  2. re-bootstapping Metals with `:MetalsInstall`
  3. Wanting to then test those changes without having to close and
     re-open nvim.

This adds in a new `:MetalsRestartServer` which will allow for me to do
just that. Also, it adds in a `:MetalsStartServer` in the case that a
user is using this for the first time and installs Metals. To get
started they used to have to close and reopen, but now after the initial
install they can just use the new `:MetalsStartServer` command.

Closes #118 