### PR TITLE
Remove `:Format` command.

### DIFF
--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -367,7 +367,6 @@ handle it.
 COMMANDS                                                       *metals-commands*
 
 The following commands are provided by nvim-metals:
-  * |Format|
   * |MetalsAmmoniteEnd|
   * |MetalsAmmoniteStart|
   * |MetalsBspSwitch|
@@ -392,10 +391,6 @@ The following commands are provided by nvim-metals:
   * |MetalsRestartServer|
   * |MetalsSourcesScan|
   * |MetalsStartServer|
-
-                                                                        *Format*
-Format                       Format the current buffer utilizing. (Make sure to
-                             have a .scalafmt.conf file.)
 
                                                              *MetalsAmmoniteEnd*
 MetalsAmmoniteEnd            End the Ammonite BSP Server.

--- a/plugin/metals.vim
+++ b/plugin/metals.vim
@@ -2,8 +2,6 @@ if exists('g:nvim_metals_loaded')
   finish
 endif
 
-command! Format lua vim.lsp.buf.formatting()
-
 command! MetalsAmmoniteEnd lua require'metals'.ammonite_end()
 command! MetalsAmmoniteStart lua require'metals'.ammonite_start()
 command! MetalsBspSwitch lua require'metals'.bsp_switch()


### PR DESCRIPTION
This was sort of left over from when I just started the plugin and was
also creating extra LSP helper commands. This is the last one left that
I sort of just forgot about, and it probably just shouldn't be in here.
All it's doing is just calling `vim.lsp.buf.formatting()`, so it can
very easily be mapped locally. Plus most people may already have this
mapped directly calling that anyways.

Plus, is is also conflicting with another plugin:
  https://github.com/mhartington/formatter.nvim/issues/35