### PR TITLE
Add in a `metals_disabled_mode` option.

### DIFF
--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -352,6 +352,21 @@ The hightlight group that will be used to show decorations. For example, this
 will change the way worksheet evaluations are displayed in `*.worksheet.sc`
 file.
 
+                                                        *g:metals_disabled_mode*
+Type: boolean ~
+Default: false ~
+
+Used in the situation where you don't want Metals to start by default when you
+enter a Scala workspace. WARNING: Use this with caution though as it may be
+confusing why Metals isn't starting when you're in a workspace and you forgot
+you have this set. If using this, once you'd like to use Metals in a specific
+workspace you'll need to manually start the server via |MetalsStartServer| or
+via a mapping with |start_server()|. Then it will continue to work in that
+workspace until you close it. NOTE: The choice isn't persisted, so you need to
+continually do this every time you want to use it even in the same workspace.
+If people _actually_ use this setting and want that, submit a feature request,
+if not it's not worth the extra work.
+
                                                 *g:metals_use_global_executable*
 Type: boolean ~
 Default: false ~

--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -260,7 +260,10 @@ M.restart_server = function()
 end
 
 M.start_server = function()
-  setup.initialize_or_attach(setup.config)
+  if vim.g.metals_disabled_mode then
+    setup.explicitly_enable()
+  end
+  setup.initialize_or_attach(setup.config_cache)
 end
 
 -- Since we want metals to be the entrypoint for everything, just for ensure that it's


### PR DESCRIPTION
This will allow a user to set this to block Metals from starting by
default all of the time when they may not want it to.

Still not 100% sure on this as I think it may be annoying to have to manually do this for a workspace that you do want to have regularly enabled. So one thing I'm thinking about it is to just create a file at the workspace root, like `.metals/nvim-metals.txt` and if that file exists, then even if the user has the `metals_disabled_mode` set to `true`, it would still start in that workspace. If anyone out there is planning on using this, lemme know your thoughts.

Closes #119 

For now, I'm just going to leave this as if. If someone actually uses it and like it and they get annoyed by having to manually do it in the same workspace all the time, we can adjust and enhance then.