### PR TITLE
Add in the ability to pass in other args to the DAP process

### DIFF
--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -828,7 +828,19 @@ metals configuration with the following `on_attach` function. >
 This will ensure that the correct |dap-adapter| is configured for Scala.
 You'll also then want to ensure you have configurations setup for Scala. These
 configurations are the configurations explained in |dap-configuration| with a
-metals-specific field added, `metalsRunType`.
+metals-specific table added under the `metals` key. The valid keys in the
+metals table are as follows: >
+  metals = {
+    runType = "run",
+    args = { "foo", "bar" },
+    jvmOptions = { "-Dpropert=123" },
+    env = { "RETRY" = "TRUE" },
+    envFile = ".env"
+  }
+<
+
+You can also read about the various keys and their meaning here in the Metals
+docs https://scalameta.org/metals/docs/integrations/debug-adapter-protocol.html
 
 The following run types are valid for Metals.
   - `run` (automatically discovers the main method and runs it for the current
@@ -845,23 +857,30 @@ types. >
 
   dap.configurations.scala = {
     {
-       type = 'scala',
-       request = 'launch',
-       name = 'Run',
-       metalsRunType = 'run'
+      type = "scala",
+      request = "launch",
+      name = "Run",
+      metals = {
+        runType = "run",
+      },
     },
     {
-       type = 'scala',
-       request = 'launch',
-       name = 'Test File',
-       metalsRunType = 'testFile'
+      type = "scala",
+      request = "launch",
+      name = "Test File",
+      metals = {
+        runType = "testFIle",
+      },
     },
     {
-       type = 'scala',
-       request = 'launch',
-       name = 'Test Target',
-       metalsRunType = 'testTarget'
-    }
+      type = "scala",
+      request = "launch",
+      name = "Test Target",
+      metals = {
+        runType = "testTarget",
+      },
+    },
   }
 <
+
 vim:tw=80:ts=2:ft=help:

--- a/lua/metals/diagnostic.lua
+++ b/lua/metals/diagnostic.lua
@@ -24,7 +24,6 @@ local function get_all_lsp_diagnostics_as_qfitems()
       if d.severity == 1 then
         item.type = "E"
         qfitems[#qfitems + 1] = item
-
       elseif d.severity == 2 then
         item.type = "W"
         warnings[#warnings + 1] = item

--- a/lua/metals/setup.lua
+++ b/lua/metals/setup.lua
@@ -2,7 +2,6 @@ local api = vim.api
 local lsp = vim.lsp
 local fn = vim.fn
 local uv = vim.loop
-
 local default_handlers = require("metals.handlers")
 local log = require("metals.log")
 local messages = require("metals.messages")
@@ -354,10 +353,17 @@ M.setup_dap = function(execute_command)
 
   dap.adapters.scala = function(callback, config)
     local uri = vim.uri_from_bufnr(0)
-    local runType = config.metalsRunType or "run"
+    local metals_dap_settings = config.metals or {}
     execute_command({
       command = "metals.debug-adapter-start",
-      arguments = { path = uri, runType = runType },
+      arguments = {
+        path = uri,
+        runType = metals_dap_settings.runType or "run",
+        args = metals_dap_settings.args,
+        jvmOptions = metals_dap_settings.jvmOptions,
+        env = metals_dap_settings.env,
+        envFile = metals_dap_settings.envFile,
+      },
     }, function(_, _, res)
       -- In metals we throw various exceptions when hanlding
       -- debug-adapter-start but they are all handled and status messages are
@@ -374,7 +380,7 @@ M.setup_dap = function(execute_command)
           enrich_config = function(_config, on_config)
             local final_config = vim.deepcopy(_config)
             -- Just incase strip this out since it's metals-specific
-            final_config.metalsRunType = nil
+            final_config.metals = nil
             on_config(final_config)
           end,
         })


### PR DESCRIPTION
NOTE: This does break the existing mappings. For example you no longer
have a `metalRunType` key in your configuration table, but now you have
a full `metals` table. So before you would have had something like:

```lua
    {
      type = "scala",
      request = "launch",
      name = "Run",
      metalsRunType = "run"
    },
```

Where now you'll want to replace the `metalsRunType` with a `metals` key
and a `runType` key in the `metals` table. For example:

```lua
    {
      type = "scala",
      request = "launch",
      name = "Run",
      metals = {
        runType = "run"
      }
    },
```

This also adds in some new keys:

```
  args = { "firstArg", "secondArg", "thirdArg" },
  jvmOptions = {},
  env = {},
  envFile = "",
```
All of these can be set in the `metals` table.

Closes #129 