### PR TITLE
Remove our `textDocument/hover` implementation.

### DIFF
--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -802,16 +802,6 @@ The spec for this can be found here:
 
 https://scalameta.org/metals/docs/editors/new-editor.html#metalsexecuteclientcommand
 
-                                                        *['textDocument/hover']*
-['textDocument/hover']({err}, {method}, {result})
-                          Used to override the default ["textDocument/hover"]
-                          callback since the default doesn't wrap lines.
-
-                          Parameters:
-                          {err}    Hover error
-                          {method} textDocument/hover
-                          {result} hover results from the server
-
 ================================================================================
 FUNCTIONS                                                     *metals-functions*
 

--- a/lua/metals/handlers.lua
+++ b/lua/metals/handlers.lua
@@ -6,7 +6,6 @@ local decoration = require("metals.decoration")
 local diagnostic = require("metals.diagnostic")
 local doctor = require("metals.doctor")
 local log = require("metals.log")
-local ui = require("metals.ui")
 local util = require("metals.util")
 
 local M = {}
@@ -62,29 +61,6 @@ M["metals/executeClientCommand"] = function(_, _, resp)
   else
     log.warn_and_show(string.format("Looks like nvim-metals doesn't handle %s yet.", resp.command))
   end
-end
-
--- An alternative to the hover provided by nvim LSP. Why? The default
--- implementation doesn't wrap at all, and in Scala when you have methods with
--- long signatures, this gets very annyoing.  In the future, the hope is that
--- this will just be handled upstream better and we can just remove this method
--- here.
-M["textDocument/hover"] = function(_, method, result)
-  local opts = { pad_left = 1, pad_right = 1 }
-  lsp.util.focusable_float(method, function()
-    if not (result and result.contents) then
-      return
-    end
-    local markdown_lines = lsp.util.convert_input_to_markdown_lines(result.contents)
-    markdown_lines = lsp.util.trim_empty_lines(markdown_lines)
-    if vim.tbl_isempty(markdown_lines) then
-      return
-    end
-    local bufnr, winnr = lsp.util.fancy_floating_markdown(markdown_lines, opts)
-    lsp.util.close_preview_autocmd({ "CursorMoved", "BufHidden", "InsertCharPre" }, winnr)
-    ui.wrap_hover(bufnr, winnr)
-    return bufnr, winnr
-  end)
 end
 
 -- Callback function to handle `metals/status`


### PR DESCRIPTION
The main reason we had our own `textDocument/hover` in here was due to the
default one not wrapping. This caused some issues with type signatures that were
quite long and not being able to see the whole thing. Now due to the improvements
in https://github.com/neovim/neovim/pull/14649 we can just remove our since the
default one now wraps.