### PR TITLE
Remove usage of fancy_floating_markdown.

### DIFF
--- a/lua/metals/decoration.lua
+++ b/lua/metals/decoration.lua
@@ -29,7 +29,7 @@ M.worksheet_hover = function()
     return
   end
 
-  local bufnr, winnr = lsp.util.fancy_floating_markdown(hover_message, { pad_left = 1, pad_right = 1 })
+  local bufnr, winnr = lsp.util.open_floating_preview(hover_message, "markdown", { pad_left = 1, pad_right = 1 })
 
   lsp.util.close_preview_autocmd({ "CursorMoved", "BufHidden", "InsertCharPre" }, winnr)
   ui.wrap_hover(bufnr, winnr)


### PR DESCRIPTION
This was removed from NeoVim, so we need to switch to directly
use `open_floating_preview`.