### PR TITLE
fix readme with main branch and Neovim typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # nvim-metals
 
 nvim-metals is a Lua plugin built to provide a better experience while using
-Metals, the Scala Language Server, with NeoVim's built-in [LSP
+Metals, the Scala Language Server, with Neovim's built-in [LSP
 support](https://neovim.io/doc/user/lsp.html). This plugin provides the
 necessary commands you'll need to develop with nvim and Metals. This extension
 also implements many of the custom Metals LSP extensions that will give you a
@@ -29,7 +29,9 @@ integrations with other projects such as
     version of nvim, v.0.5.x.
 - Ensure [Coursier](https://get-coursier.io/docs/cli-installation) is installed
     on your machine. `nvim-metals` uses Coursier to download and update Metals.
-- Remove `F` from `shortmess`. `set shortmess-=F` _NOTE_: Without doing this,
+- Remove `F` from `shortmess`. `set shortmess-=F`
+    (for lua `vim.o.shortmess = string.gsub(vim.o.shortmess, "F", "") .. "c"`)
+    _NOTE_: Without doing this,
     autocommands that deal with filetypes prohibit messages from being shown...
     and since we heavily rely on this, this _must_ be set.
 - Ensure that you have mappings created for functionality that you desire. By
@@ -44,7 +46,7 @@ _NOTE_: This plugin works without needing to install
 [neovim/nvim-lspconfig](https://github.com/neovim/nvim-lspconfig). If you have
 it installed for other languages, that's not a problem, but make sure you do not
 have Metals configured through `nvim-lspconfig` while using this plugin. If you
-have `nvim/lsp-config` registered with `nvim-lspconfig`, you'll want to remove
+have metals setup registered with `nvim-lspconfig`, you'll want to remove
 it.
 
 `nvim-metals` is just a plugin installed like any other Neovim plugin. For
@@ -55,8 +57,8 @@ use({'scalameta/nvim-metals'})
 ```
 
 NOTE: By default, the main branch of `nvim-metals` is compatible with v0.5.0 of
-NeoVim. If you'd like to test out new functionality that is added that requires
-the nightly build of NeoVim, then you can target the `next` branch:
+Neovim. If you'd like to test out new functionality that is added that requires
+the nightly build of Neovim, then you can target the `next` branch:
 
 ```lua
 use({'scalameta/nvim-metals', branch = 'next'})
@@ -65,7 +67,7 @@ use({'scalameta/nvim-metals', branch = 'next'})
 ## Getting started
 
 To get started with `nvim-metals`, _please read_ [`:help
-nvim-metals`](https://github.com/scalameta/nvim-metals/blob/master/doc/metals.txt).
+nvim-metals`](https://github.com/scalameta/nvim-metals/blob/main/doc/metals.txt).
 This will give you a thorough overview of the setup and settings.
 
 ## Settings, Commands, and Options

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ integrations with other projects such as
 - Ensure [Coursier](https://get-coursier.io/docs/cli-installation) is installed
     on your machine. `nvim-metals` uses Coursier to download and update Metals.
 - Remove `F` from `shortmess`. `set shortmess-=F`
-    (for lua `vim.o.shortmess = string.gsub(vim.o.shortmess, "F", "") .. "c"`)
+    (for lua `vim.opt_global.shortmess:remove("F"):append("c")`)
     _NOTE_: Without doing this,
     autocommands that deal with filetypes prohibit messages from being shown...
     and since we heavily rely on this, this _must_ be set.


### PR DESCRIPTION
- Consistent Neovim
- changed `master` branch reference to `main`
- `shortmess` setup for lua