### PR TITLE
Align Metals neovim commands with Metals Telescope commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ right away.
 
 ## Tooling
 
-The project uses [`lucheck`](https://github.com/mpeterv/luacheck) for static
+The project uses [`luacheck`](https://github.com/mpeterv/luacheck) for static
 code analysis, and this is ran during CI on your project. You'll need to install
 this locally via luarocks: `luarocks install luacheck`. I also use
 [`StyLua`](https://github.com/JohnnyMorganz/StyLua) for formatting. Please also
@@ -50,7 +50,7 @@ After installed you can just use the commands in the Makefile to use them.
 A helpful part of seeing what's going on when working on stuff is the various
 logging files. Starting at the most basic, you can look in the
 `.metals/metals.log` file to see basic logs given from Metals. The
-`:MetalsLogsToggle` actually just looks at this file. If you want to further
+`:MetalsToggleLogs` actually just looks at this file. If you want to further
 look at the communication between Metals and Neovim, you can create trace files
 as outlined [here on the Metals
 site](https://scalameta.org/metals/docs/contributors/getting-started.html#json-rpc-trace).

--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -415,6 +415,7 @@ The following commands are provided by nvim-metals:
   * |MetalsSwitchBsp|
   * |MetalsToggleLogs|
   * |MetalsUpdate|
+
                                                        *MetalsAnalyzeStacktrace*
 MetalsAnalyzeStacktrace      Takes the stacktrace from your current register
                              and sends it to Metals to be analyzed. This will

--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -388,39 +388,39 @@ handle it.
 COMMANDS                                                       *metals-commands*
 
 The following commands are provided by nvim-metals:
-  * |MetalsAmmoniteStart|
-  * |MetalsAmmoniteStop|
+  * |MetalsStartAmmonite|
+  * |MetalsStopAmmonite|
   * |MetalsAnalyzeStacktrace|
-  * |MetalsBspSwitch|
-  * |MetalsBuildConnect|
-  * |MetalsBuildDisconnect|
-  * |MetalsBuildImport|
-  * |MetalsBuildRestart|
+  * |MetalsSwitchBsp|
+  * |MetalsConnectBuild|
+  * |MetalsDisconnectBuild|
+  * |MetalsImportBuild|
+  * |MetalsRestartBuild|
   * |MetalsCompileCancel|
   * |MetalsCompileClean|
   * |MetalsCompileCascade|
   * |MetalsCopyWorksheetOutput|
-  * |MetalsDoctor|
+  * |MetalsRunDoctor|
   * |MetalsGenerateBspConfig|
   * |MetalsInstall|
   * |MetalsInfo|
-  * |MetalsLogToggle|
+  * |MetalsToggleLogs|
   * |MetalsNewScalaFile|
   * |MetalsNewScalaProject|
   * |MetalsOrganizeImports|
   * |MetalsQuickWorksheet|
   * |MetalsResetChoice|
   * |MetalsRestartServer|
-  * |MetalsSourcesScan|
+  * |MetalsScanSources|
   * |MetalsStartServer|
   * |MetalsSuperMethodHierarchy|
   * |MetalsUpdate|
 
-                                                           *MetalsAmmoniteStart*
-MetalsAmmoniteStart          Start the Ammonite BSP Server.
+                                                           *MetalsStartAmmonite*
+MetalsStartAmmonite          Start the Ammonite BSP Server.
 
-                                                            *MetalsAmmoniteStop*
-MetalsAmmoniteStop           Stop the Ammonite BSP Server.
+                                                            *MetalsStopAmmonite*
+MetalsStopAmmonite           Stop the Ammonite BSP Server.
 
                                                        *MetalsAnalyzeStacktrace*
 MetalsAnalyzeStacktrace      Takes the stacktrace from your current register
@@ -429,26 +429,26 @@ MetalsAnalyzeStacktrace      Takes the stacktrace from your current register
                              which will be populated with code lenses to help
                              you navigate to the trace location.
 
-                                                               *MetalsBspSwitch*
-MetalsBspSwitch              Prompts the user to select a new build server to
+                                                               *MetalsSwitchBsp*
+MetalsSwitchBsp              Prompts the user to select a new build server to
                              connect to. This command does nothing in case there
                              are less than two installed build servers on the
                              computer. In case the user has multiple BSP servers
                              installed then Metals will prompt the user to
                              select which server to use.
 
-                                                            *MetalsBuildConnect*
-MetalsBuildConnect           Manually connect to the build server.
+                                                            *MetalsConnectBuild*
+MetalsConnectBuild           Manually connect to the build server.
 
-                                                         *MetalsBuildDisconnect*
-MetalsBuildDisconnect        Manually disconnect from the build server without
+                                                         *MetalsDisconnectBuild*
+MetalsDisconnectBuild        Manually disconnect from the build server without
                              reconnecting.
 
-                                                             *MetalsBuildImport*
-MetalsBuildImport            Trigger an import for the current workspace.
+                                                             *MetalsImportBuild*
+MetalsImportBuild            Trigger an import for the current workspace.
 
-                                                            *MetalsBuildRestart*
-MetalsBuildRestart           Manually restart the build server.
+                                                            *MetalsRestartBuild*
+MetalsRestartBuild           Manually restart the build server.
 
                                                            *MetalsCompileCancel*
 MetalsCompileCancel          Cancel any ongoing compilation.
@@ -468,8 +468,8 @@ MetalsCompileCascade         Compile the current open file along with all build
 MetalsCopyWorksheetOutput    Copy the contents of a worksheet to your local
                              buffer.
 
-                                                                  *MetalsDoctor*
-MetalsDoctor                 Run Metals Doctor, which will open a floating
+                                                                  *MetalsRunDoctor*
+MetalsRunDoctor                 Run Metals Doctor, which will open a floating
                              window to show you the status of Metals.
 
                                                        *MetalsGenerateBspConfig*
@@ -493,8 +493,8 @@ MetalsInfo                   Give info about the currently installed version
                              |MetalsInstall| and also the location of the
                              `nvim-metals.log` file and some helpful links.
 
-                                                               *MetalsLogToggle*
-MetalsLogsToggle             Opens the embedded Nvim terminal tailing the
+                                                               *MetalsToggleLogs*
+MetalsToggleLogs             Opens the embedded Nvim terminal tailing the
                              |.metals/metals.log| file in your workspace. If
                              triggered again, this will either bring you to
                              the window that has the logs open, or open the
@@ -537,8 +537,8 @@ MetalsResetChoice            ResetChoicePopup command allows you to reset a
                                                            *MetalsRestartServer*
 MetalsRestartServer          Restart the Metals server.
 
-                                                             *MetalsSourcesScan*
-MetalsSourcesScan            Scan all workspaces sources.
+                                                             *MetalsScanSources*
+MetalsScanSources            Scan all workspaces sources.
 
                                                              *MetalsStartServer*
 MetalsStartServer           Start Metals server. Must be in a Scala or sbt file

--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -13,7 +13,7 @@ CONTENTS                                                           *nvim-metals*
     3.  Settings............. |metals-settings|
     4.  Options.............. |metals-options|
     5.  Commands............. |metals-commands|
-    6.  Lua API.............. |metals-lua-api|
+    6.  LUA API.............. |metals-lua-api|
     7.  TVP Module........... |metals-tvp-module|
     8.  Custom Handlers...... |metals-custom-handlers|
     9.  Functions............ |metals-functions|
@@ -388,40 +388,33 @@ handle it.
 COMMANDS                                                       *metals-commands*
 
 The following commands are provided by nvim-metals:
-  * |MetalsStartAmmonite|
-  * |MetalsStopAmmonite|
   * |MetalsAnalyzeStacktrace|
-  * |MetalsSwitchBsp|
-  * |MetalsConnectBuild|
-  * |MetalsDisconnectBuild|
-  * |MetalsImportBuild|
-  * |MetalsRestartBuild|
   * |MetalsCompileCancel|
-  * |MetalsCompileClean|
   * |MetalsCompileCascade|
+  * |MetalsCompileClean|
+  * |MetalsConnectBuild|
   * |MetalsCopyWorksheetOutput|
-  * |MetalsRunDoctor|
+  * |MetalsDisconnectBuild|
   * |MetalsGenerateBspConfig|
-  * |MetalsInstall|
+  * |MetalsImportBuild|
   * |MetalsInfo|
-  * |MetalsToggleLogs|
+  * |MetalsInstall|
   * |MetalsNewScalaFile|
   * |MetalsNewScalaProject|
   * |MetalsOrganizeImports|
   * |MetalsQuickWorksheet|
   * |MetalsResetChoice|
+  * |MetalsRestartBuild|
   * |MetalsRestartServer|
+  * |MetalsRunDoctor|
   * |MetalsScanSources|
+  * |MetalsStartAmmonite|
   * |MetalsStartServer|
+  * |MetalsStopAmmonite|
   * |MetalsSuperMethodHierarchy|
+  * |MetalsSwitchBsp|
+  * |MetalsToggleLogs|
   * |MetalsUpdate|
-
-                                                           *MetalsStartAmmonite*
-MetalsStartAmmonite          Start the Ammonite BSP Server.
-
-                                                            *MetalsStopAmmonite*
-MetalsStopAmmonite           Stop the Ammonite BSP Server.
-
                                                        *MetalsAnalyzeStacktrace*
 MetalsAnalyzeStacktrace      Takes the stacktrace from your current register
                              and sends it to Metals to be analyzed. This will
@@ -429,29 +422,12 @@ MetalsAnalyzeStacktrace      Takes the stacktrace from your current register
                              which will be populated with code lenses to help
                              you navigate to the trace location.
 
-                                                               *MetalsSwitchBsp*
-MetalsSwitchBsp              Prompts the user to select a new build server to
-                             connect to. This command does nothing in case there
-                             are less than two installed build servers on the
-                             computer. In case the user has multiple BSP servers
-                             installed then Metals will prompt the user to
-                             select which server to use.
-
-                                                            *MetalsConnectBuild*
-MetalsConnectBuild           Manually connect to the build server.
-
-                                                         *MetalsDisconnectBuild*
-MetalsDisconnectBuild        Manually disconnect from the build server without
-                             reconnecting.
-
-                                                             *MetalsImportBuild*
-MetalsImportBuild            Trigger an import for the current workspace.
-
-                                                            *MetalsRestartBuild*
-MetalsRestartBuild           Manually restart the build server.
-
                                                            *MetalsCompileCancel*
 MetalsCompileCancel          Cancel any ongoing compilation.
+
+                                                          *MetalsCompileCascade*
+MetalsCompileCascade         Compile the current open file along with all build
+                             targets that depend on it.
 
                                                             *MetalsCompileClean*
 MetalsCompileClean           Recompile all build targets in this workspace. By
@@ -460,30 +436,29 @@ MetalsCompileClean           Recompile all build targets in this workspace. By
                              command might be run to make sure everything is
                              recompiled correctly.
 
-                                                          *MetalsCompileCascade*
-MetalsCompileCascade         Compile the current open file along with all build
-                             targets that depend on it.
+                                                            *MetalsConnectBuild*
+MetalsConnectBuild           Manually connect to the build server.
 
                                                      *MetalsCopyWorksheetOutput*
 MetalsCopyWorksheetOutput    Copy the contents of a worksheet to your local
                              buffer.
 
-                                                                  *MetalsRunDoctor*
-MetalsRunDoctor                 Run Metals Doctor, which will open a floating
-                             window to show you the status of Metals.
+                                                         *MetalsDisconnectBuild*
+MetalsDisconnectBuild        Manually disconnect from the build server without
+                             reconnecting.
 
                                                        *MetalsGenerateBspConfig*
-MetalsGenerateBspConfig      Checks to see if your build tool can serve as a BSP
-                             server. If so, generate the necessary BSP config to
-                             connect to the server. If there is more than one
-                             build tool for a workspace, you can then choose the
-                             desired one and that one will be used to generate
-                             the config. After the config is generated, Metals
-                             will attempt to auto-connect to it.
+MetalsGenerateBspConfig      Checks to see if your build tool can serve as a
+                             BSP server. If so, generate the necessary BSP
+                             config to connect to the server. If there is more
+                             than one build tool for a workspace, you can then
+                             choose the desired one and that one will be used 
+                             to generate the config. After the config is 
+                             generated, Metals will attempt to auto-connect to
+                             it.
 
-                                                                 *MetalsInstall*
-MetalsInstall                Install Metals. NOTE that behind the scenes this
-                             calls the exact same function as |MetalsUpdate|.
+                                                             *MetalsImportBuild*
+MetalsImportBuild            Trigger an import for the current workspace.
 
                                                                     *MetalsInfo*
 MetalsInfo                   Give info about the currently installed version
@@ -493,12 +468,9 @@ MetalsInfo                   Give info about the currently installed version
                              |MetalsInstall| and also the location of the
                              `nvim-metals.log` file and some helpful links.
 
-                                                               *MetalsToggleLogs*
-MetalsToggleLogs             Opens the embedded Nvim terminal tailing the
-                             |.metals/metals.log| file in your workspace. If
-                             triggered again, this will either bring you to
-                             the window that has the logs open, or open the
-                             buffer in a split in your current window.
+                                                                 *MetalsInstall*
+MetalsInstall                Install Metals. NOTE that behind the scenes this
+                             calls the exact same function as |MetalsUpdate|.
 
                                                             *MetalsNewScalaFile*
 MetalsNewScalaFile           Create a new Scala file. This will produce a
@@ -507,15 +479,15 @@ MetalsNewScalaFile           Create a new Scala file. This will produce a
                              also prompts for a name.
 
                                                          *MetalsNewScalaProject*
-MetalsNewScalaProject       Create a new Scala project using one of the
-                            available g8 templates. This includes simple
-                            projects as well as samples for most of the popular
-                            Scala frameworks.
+MetalsNewScalaProject        Create a new Scala project using one of the
+                             available g8 templates. This includes simple
+                             projects as well as samples for most of the popular
+                             Scala frameworks.
 
                                                          *MetalsOrganizeImports*
-MetalsOrganizeImports       Sends a code action request to Metals to organize
-                            imports. NOTE: that this is blocking, and it has a
-                            timeout of 1000ms.
+MetalsOrganizeImports        Sends a code action request to Metals to organize
+                             imports. NOTE: that this is blocking, and it has a
+                             timeout of 1000ms.
 
                                                           *MetalsQuickWorksheet*
 MetalsQuickWorksheet         Creates a worksheet in the current directory that
@@ -531,51 +503,75 @@ MetalsQuickWorksheet         Creates a worksheet in the current directory that
                                                              *MetalsResetChoice*
 MetalsResetChoice            ResetChoicePopup command allows you to reset a
                              decision you made about different settings.
-                             E.g. If you choose to import workspace with sbt you
-                             can decide to reset and change it again.
+                             E.g. If you choose to import workspace with sbt 
+                             you can decide to reset and change it again.
+
+                                                            *MetalsRestartBuild*
+MetalsRestartBuild           Manually restart the build server.
 
                                                            *MetalsRestartServer*
 MetalsRestartServer          Restart the Metals server.
 
+                                                                *MetalsRunDoctor*
+MetalsRunDoctor                 Run Metals Doctor, which will open a floating
+                             window to show you the status of Metals.
+
                                                              *MetalsScanSources*
 MetalsScanSources            Scan all workspaces sources.
 
+                                                           *MetalsStartAmmonite*
+MetalsStartAmmonite          Start the Ammonite BSP Server.
+
                                                              *MetalsStartServer*
-MetalsStartServer           Start Metals server. Must be in a Scala or sbt file
-                            in a workspace where Metals is not yet started.
+MetalsStartServer            Start Metals server. Must be in a Scala or sbt file
+                             in a workspace where Metals is not yet started.
+
+                                                            *MetalsStopAmmonite*
+MetalsStopAmmonite           Stop the Ammonite BSP Server.
 
                                                     *MetalsSuperMethodHierarchy*
-MetalsSuperMethodHierarchy  Gathers the inheritance hierarchy of a member and
-                            if more than one is found, the user is given a quick
-                            pick option to jump to the point in the hierarchy
-                            tree selected.
+MetalsSuperMethodHierarchy   Gathers the inheritance hierarchy of a member and
+                             if more than one is found, the user is given a
+                             quick pick option to jump to the point in the
+                             hierarchy tree selected.
+
+                                                               *MetalsSwitchBsp*
+MetalsSwitchBsp              Prompts the user to select a new build server to
+                             connect to. This command does nothing in case there
+                             are less than two installed build servers on the
+                             computer. In case the user has multiple BSP servers
+                             installed then Metals will prompt the user to
+                             select which server to use.
+
+                                                               *MetalsToggleLogs*
+MetalsToggleLogs             Opens the embedded Nvim terminal tailing the
+                             |.metals/metals.log| file in your workspace. If
+                             triggered again, this will either bring you to
+                             the window that has the logs open, or open the
+                             buffer in a split in your current window.
 
                                                                   *MetalsUpdate*
-MetalsUpdate                Update to the latest stable version of Metals or
-                            change versions to the new version you added in
-                            |metals_server_version|. NOTE
-                            that behind the scenes this calls the same function
-                            as |MetalsInstall|.
+MetalsUpdate                 Update to the latest stable version of Metals or
+                             change versions to the new version you added in
+                             |metals_server_version|.
+                             NOTE that behind the scenes this calls the same
+                             function as |MetalsInstall|.
 
 ================================================================================
 LUA API                                                         *metals-lua-api*
 
 The following Lua module functions are exposed for you to use via mappings.
 In order to use any of these you'd need to require the module. As an example,
-if you wanted to bind the |buid_import()| to a mapping, the right hand side of
+if you wanted to bind the |import_build()| to a mapping, the right hand side of
 the mapping would be: >
 
-    <cmd>lua require("metals").build_import()<CR>
+    <cmd>lua require("metals").import_build()<CR>
 <
 
 Note: Most of these that are just executing a command have commands that you
-can find above in |metals-commands| with more details.
-
-                                                                *ammonite_end()*
-ammonite_end()            Use to execute a |metals.ammonite-end| command.
-
-                                                              *ammonite_start()*
-ammonite_start()          Use to execute a |metals.ammonite-start| command.
+can find above in |metals-commands| with more details. Please keep in mind
+that here we are trying to unify command names with verb followed by noun.
+That's why nvim-metals lua commands sometimes differ from metals commands.
 
                                                           *analyze_stacktrace()*
 analyze_stacktrace()      Use to execute a |metals.analyze-stacktrace| command.
@@ -584,21 +580,6 @@ analyze_stacktrace()      Use to execute a |metals.analyze-stacktrace| command.
 bare_config
                           An empty config table with empty tables also set for
                           settings, handlers, and init_options.
-
-                                                                  *bsp_switch()*
-bsp_switch()              Use to execute a |metals.bsp-switch| command.
-
-                                                               *build_connect()*
-build_connect()           Use to execute a |metals.build-connect| command.
-
-                                                            *build_disconnect()*
-build_disconnect()        Use to execute a |metals.build-disconnect| command.
-
-                                                                *build_import()*
-build_import()            Use to execute a |metals.build-import| command.
-
-                                                               *build_restart()*
-build_restart()           Use to execute a |metals.build-restart| command.
 
                                                               *compile_cancel()*
 compile_cancel()          Use to execute a |metals.compile-cancel| command.
@@ -609,15 +590,25 @@ compile_cascade()         Use to execute a |metals.compile-cascade| command.
                                                                *compile_clean()*
 compile_clean()           Use to execute a |metals.compile-clean| command.
 
+                                                               *connect_build()*
+connect_build()           Use to execute a |metals.build-connect| command.
+
                                                        *copy_worksheet_output()*
 copy_worksheet_output()   Use to execute a |metals.copy-worksheet-output|
                           command.
 
-                                                                  *doctor_run()*
-doctor_run()              Use to execute a |metals.doctor-run| command.
+                                                            *disconnect_build()*
+disconnect_build()        Use to execute a |metals.build-disconnect| command.
 
                                                          *generate_bsp_config()*
-generate_bsp_config()    Use to execute a |metals.generate-bsp-config| command.
+generate_bsp_config()     Use to execute a |metals.generate-bsp-config| command.
+
+                                                             *hover_worksheet()*
+hover_worksheet()         Use to expand the decoration to show the full hover
+                          message that was returned from the decoration.
+
+                                                                *import_build()*
+import_build()            Use to execute a |metals.build-import| command.
 
                                                                         *info()*
 info()                    Give info about the currently installed version of
@@ -688,67 +679,78 @@ install_or_update()       Install Metals if it doesn't exist or update to the
                           latest stable version or version set if
                           |g.metals_server_version| is set.
 
-                                                                 *logs_toggle()*
-logs_toggle()             Use to trigger a |tail -f .metals/log| on your current
-                          workspace that will open in the embedded Neovim
-                          terminal.
-
                                                               *new_scala_file()*
 new_scala_file({directory_uri_opt}, {name_opt}, {file_type_option})
 
-                         Use to execute a |metals.new-scala-file| command. All
-                         of the params are optional. If they are not provided
-                         you will be prompted for them.
+                          Use to execute a |metals.new-scala-file| command. All
+                          of the parameters are optional. If they are not
+                          provided you will be prompted for them.
 
-                         Parameters:
-                         {directory_uri_opt} (string) directory that you'd
-                         like the new file to be created in.
+                          Parameters:
+                          {directory_uri_opt} (string) directory that you'd
+                          like the new file to be created in.
 
-                         {name_opt} (string) name you'd like to be given to the
-                         file.
+                          {name_opt} (string) name you'd like to be given to 
+                          the file.
 
-                         {file_type_option} (string) the type of Scala file
-                         that you'd like to be created.
+                          {file_type_option} (string) the type of Scala file
+                          that you'd like to be created.
 
                                                            *new_scala_project()*
-new_scala_project()      Use to execute a |metals.new-scala-project| command.
+new_scala_project()       Use to execute a |metals.new-scala-project| command.
 
-
-open_all_diagnostics()   Fills the quickfix list with the LSP diagnostics
-                         for all buffers and opens it.
-                         WARNING: Automatic updates in the quickfix for new
-                         diagnostics are not yet implemented.
-                         After opening the quickfix, in order to refresh
-                         diagnostics the function must be called again.
+                                                        *open_all_diagnostics()*
+open_all_diagnostics()    Fills the quickfix list with the LSP diagnostics
+                          for all buffers and opens it.
+                          WARNING: Automatic updates in the quickfix for new
+                          diagnostics are not yet implemented.
+                          After opening the quickfix, in order to refresh
+                          diagnostics the function must be called again.
 
                                                             *organize_imports()*
-organize_imports()       Use a code action request to get edits from Metals to
-                         organize imports for the current buffer.
+organize_imports()        Use a code action request to get edits from Metals
+                          to organize imports for the current buffer.
 
                                                              *quick_worksheet()*
-quick_worksheet()        Create a quick worksheet in your current dir with the
-                         name of your current dir.
+quick_worksheet()         Create a quick worksheet in your current dir with 
+                          the name of your current dir.
 
                                                                 *reset_choice()*
-reset_choice()           Use to execute a |metals.reset-choice| command.
+reset_choice()            Use to execute a |metals.reset-choice| command.
+
+                                                               *restart_build()*
+restart_build()           Use to execute a |metals.build-restart| command.
 
                                                               *restart_server()*
-restart_server()         Restart the Metals server.
+restart_server()          Restart the Metals server.
 
-                                                                *sources_scan()*
-sources_scan()           Use to execute a |metals.sources-scan| command.
+                                                                  *run_doctor()*
+run_doctor()              Use to execute a |metals.doctor-run| command.
+
+                                                                *scan_sources()*
+scan_sources()            Use to execute a |metals.sources-scan| command.
+
+                                                              *start_ammonite()*
+start_ammonite()          Use to execute a |metals.ammonite-start| command.
 
                                                                 *start_server()*
-start_server()           Start Metals server. Must be in a Scala or sbt file in
-                         a workspace where Metals is not yet started.
+start_server()            Start Metals server. Must be in a Scala or sbt file 
+                          in a workspace where Metals is not yet started.
+
+                                                               *stop_ammonite()*
+stop_ammonite()           Use to execute a |metals.ammonite-stop| command.
 
                                                       *super_method_hierarchy()*
-super_method_hierarchy() Use to execute a |metals.super-method-hierarchy|
-                         command.
+super_method_hierarchy()  Use to execute a |metals.super-method-hierarchy|
+                          command.
 
-                                                             *worksheet_hover()*
-worksheet_hover()        Use to expand the decoration to show the full hover
-                         message that was returned from the decoration.
+                                                                  *switch_bsp()*
+switch_bsp()              Use to execute a |metals.bsp-switch| command.
+
+                                                                 *toggle_logs()*
+toggle_logs()             Use to trigger a |tail -f .metals/log| on your
+                          current workspace that will open in the embedded
+                          Neovim terminal.
 
 ================================================================================
 METALS TVP MODULE                                            *metals-tvp-module*
@@ -967,7 +969,7 @@ to be autocompleted when trying to trigger it via: >
 Then you'll want to explicitly enable it. NOTE that by doing this it will no
 longer be lazy loaded. >
 
-  require('telescope').extensions.metals.commands()
+  require("telescope").extensions.metals.commands()
 
 <
 

--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -40,9 +40,8 @@ end
 
 --not supported
 M.ammonite_start = function()
-  log.error_and_show("ammonite_start() is not supported, use require(\"metals\").start_ammonite() instead.")
+  log.error_and_show('ammonite_start() is not supported, use require("metals").start_ammonite() instead.')
 end
-
 
 M.stop_ammonite = function()
   execute_command({ command = "metals.ammonite-stop" })
@@ -50,7 +49,7 @@ end
 
 --not supported
 M.ammonite_stop = function()
-  log.error_and_show("ammonite_stop() is not supported, use require(\"metals\").stop_ammonite() instead.")
+  log.error_and_show('ammonite_stop() is not supported, use require("metals").stop_ammonite() instead.')
 end
 
 M.switch_bsp = function()
@@ -59,7 +58,7 @@ end
 
 --not supported
 M.bsp_switch = function()
-  log.error_and_show("bsp_switch() not supported, use require(\"metals\").switch_bsp() instead.")
+  log.error_and_show('bsp_switch() not supported, use require("metals").switch_bsp() instead.')
 end
 
 M.connect_build = function()
@@ -68,7 +67,7 @@ end
 
 --deprecated
 M.build_connect = function()
-  log.warn_and_show("build_connect() is deprecated, use require(\"metals\").connect_build() instead.")
+  log.warn_and_show('build_connect() is deprecated, use require("metals").connect_build() instead.')
   M.connect_build()
 end
 
@@ -78,7 +77,7 @@ end
 
 --deprecated
 M.build_disconnect = function()
-  log.warn_and_show("build_disconnect() is deprecated, use require(\"metals\").disconnect_build() instead.")
+  log.warn_and_show('build_disconnect() is deprecated, use require("metals").disconnect_build() instead.')
   M.disconnect_build()
 end
 
@@ -88,7 +87,7 @@ end
 
 --deprecated
 M.build_import = function()
-  log.warn_and_show("build_import() is deprecated, use require(\"metals\").import_build() instead.")
+  log.warn_and_show('build_import() is deprecated, use require("metals").import_build() instead.')
   M.import_build()
 end
 
@@ -98,7 +97,7 @@ end
 
 --deprecated
 M.build_restart = function()
-  log.warn_and_show("build_restart() is deprecated, use require(\"metals\").restart_build() instead.")
+  log.warn_and_show('build_restart() is deprecated, use require("metals").restart_build() instead.')
   M.restart_build()
 end
 
@@ -142,7 +141,7 @@ end
 
 --not supported
 M.doctor_run = function()
-  log.error_and_show("doctor_run() is not supported, use require(\"metals\").run_doctor() instead.")
+  log.error_and_show('doctor_run() is not supported, use require("metals").run_doctor() instead.')
 end
 
 M.generate_bsp_config = function()
@@ -219,7 +218,7 @@ end
 
 --not supported
 M.logs_toggle = function()
-  log.error_and_show("logs_toggle() is not supported, use require(\"metals\").toggle_logs() instead.")
+  log.error_and_show('logs_toggle() is not supported, use require("metals").toggle_logs() instead.')
 end
 
 -- Implements the new-scala-file feature.
@@ -258,7 +257,7 @@ end
 
 --deprecated
 M.sources_scan = function()
-  log.warn_and_show("sources_scan() is deprecated, use require(\"metals\").scan_sources() instead.")
+  log.warn_and_show('sources_scan() is deprecated, use require("metals").scan_sources() instead.')
   M.scan_sources()
 end
 
@@ -345,8 +344,7 @@ M.hover_worksheet = decoration.hover_worksheet
 
 --not supported
 M.worksheet_hover = function()
-  log.error_and_show("worksheet_hover() is not supported, use require(\"metals\").hover_worksheet() instead.")
-  M.hover_worksheet()
+  log.error_and_show('worksheet_hover() is not supported, use require("metals").hover_worksheet() instead.')
 end
 
 M.open_all_diagnostics = diagnostic.open_all_diagnostics

--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -38,28 +38,68 @@ M.start_ammonite = function()
   execute_command({ command = "metals.ammonite-start" })
 end
 
+--not supported
+M.ammonite_start = function()
+  log.error_and_show("ammonite_start() is not supported, use require(\"metals\").start_ammonite() instead.")
+end
+
+
 M.stop_ammonite = function()
   execute_command({ command = "metals.ammonite-stop" })
+end
+
+--not supported
+M.ammonite_stop = function()
+  log.error_and_show("ammonite_stop() is not supported, use require(\"metals\").stop_ammonite() instead.")
 end
 
 M.switch_bsp = function()
   execute_command({ command = "metals.bsp-switch" })
 end
 
+--not supported
+M.bsp_switch = function()
+  log.error_and_show("bsp_switch() not supported, use require(\"metals\").switch_bsp() instead.")
+end
+
 M.connect_build = function()
   execute_command({ command = "metals.build-connect" })
+end
+
+--deprecated
+M.build_connect = function()
+  log.warn_and_show("build_connect() is deprecated, use require(\"metals\").connect_build() instead.")
+  M.connect_build()
 end
 
 M.disconnect_build = function()
   execute_command({ command = "metals.build-disconnect" })
 end
 
+--deprecated
+M.build_disconnect = function()
+  log.warn_and_show("build_disconnect() is deprecated, use require(\"metals\").disconnect_build() instead.")
+  M.disconnect_build()
+end
+
 M.import_build = function()
   execute_command({ command = "metals.build-import" })
 end
 
+--deprecated
+M.build_import = function()
+  log.warn_and_show("build_import() is deprecated, use require(\"metals\").import_build() instead.")
+  M.import_build()
+end
+
 M.restart_build = function()
   execute_command({ command = "metals.build-restart" })
+end
+
+--deprecated
+M.build_restart = function()
+  log.warn_and_show("build_restart() is deprecated, use require(\"metals\").restart_build() instead.")
+  M.restart_build()
 end
 
 M.compile_cancel = function()
@@ -98,6 +138,11 @@ end
 
 M.run_doctor = function()
   execute_command({ command = "metals.doctor-run" })
+end
+
+--not supported
+M.doctor_run = function()
+  log.error_and_show("doctor_run() is not supported, use require(\"metals\").run_doctor() instead.")
 end
 
 M.generate_bsp_config = function()
@@ -172,6 +217,11 @@ M.toggle_logs = function()
   vim.b["metals_buf_purpose"] = "logs"
 end
 
+--not supported
+M.logs_toggle = function()
+  log.error_and_show("logs_toggle() is not supported, use require(\"metals\").toggle_logs() instead.")
+end
+
 -- Implements the new-scala-file feature.
 -- https://scalameta.org/metals/docs/integrations/new-editor/#create-new-scala-file
 --
@@ -204,6 +254,12 @@ end
 
 M.scan_sources = function()
   execute_command({ command = "metals.sources-scan" })
+end
+
+--deprecated
+M.sources_scan = function()
+  log.warn_and_show("sources_scan() is deprecated, use require(\"metals\").scan_sources() instead.")
+  M.scan_sources()
 end
 
 M.reset_choice = function()
@@ -284,7 +340,15 @@ M.bare_config = setup.bare_config
 M.initialize_or_attach = setup.initialize_or_attach
 M.install = setup.install_or_update
 M.update = setup.install_or_update
+
 M.hover_worksheet = decoration.hover_worksheet
+
+--not supported
+M.worksheet_hover = function()
+  log.error_and_show("worksheet_hover() is not supported, use require(\"metals\").hover_worksheet() instead.")
+  M.hover_worksheet()
+end
+
 M.open_all_diagnostics = diagnostic.open_all_diagnostics
 M.setup_dap = function()
   setup.setup_dap(execute_command)

--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -34,31 +34,31 @@ M.analyze_stacktrace = function()
   end
 end
 
-M.ammonite_start = function()
+M.start_ammonite = function()
   execute_command({ command = "metals.ammonite-start" })
 end
 
-M.ammonite_stop = function()
+M.stop_ammonite = function()
   execute_command({ command = "metals.ammonite-stop" })
 end
 
-M.bsp_switch = function()
+M.switch_bsp = function()
   execute_command({ command = "metals.bsp-switch" })
 end
 
-M.build_connect = function()
+M.connect_build = function()
   execute_command({ command = "metals.build-connect" })
 end
 
-M.build_disconnect = function()
+M.disconnect_build = function()
   execute_command({ command = "metals.build-disconnect" })
 end
 
-M.build_import = function()
+M.import_build = function()
   execute_command({ command = "metals.build-import" })
 end
 
-M.build_restart = function()
+M.restart_build = function()
   execute_command({ command = "metals.build-restart" })
 end
 
@@ -96,7 +96,7 @@ M.copy_worksheet_output = function()
   end
 end
 
-M.doctor_run = function()
+M.run_doctor = function()
   execute_command({ command = "metals.doctor-run" })
 end
 
@@ -148,7 +148,7 @@ M.info = function()
   end
 end
 
-M.logs_toggle = function()
+M.toggle_logs = function()
   local bufs = api.nvim_list_bufs()
 
   for _, buf in ipairs(bufs) do
@@ -202,7 +202,7 @@ M.quick_worksheet = function()
   M.new_scala_file(dir, name, "worksheet")
 end
 
-M.sources_scan = function()
+M.scan_sources = function()
   execute_command({ command = "metals.sources-scan" })
 end
 

--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -284,7 +284,7 @@ M.bare_config = setup.bare_config
 M.initialize_or_attach = setup.initialize_or_attach
 M.install = setup.install_or_update
 M.update = setup.install_or_update
-M.worksheet_hover = decoration.worksheet_hover
+M.hover_worksheet = decoration.hover_worksheet
 M.open_all_diagnostics = diagnostic.open_all_diagnostics
 M.setup_dap = function()
   setup.setup_dap(execute_command)

--- a/lua/metals/commands.lua
+++ b/lua/metals/commands.lua
@@ -6,44 +6,9 @@
 -- issue we wait.
 local commands_table = {
   {
-    id = "start_ammonite",
-    label = "Start Ammonite",
-    hint = "Start the Ammonite build server.",
-  },
-  {
-    id = "stop_ammonite",
-    label = "Stop Ammonite",
-    hint = "Stop the Ammonite build server.",
-  },
-  {
     id = "analyze_stacktrace",
     label = "Analyze Stacktrace",
-    hint = "Analyze stacktrace frop clipboard.",
-  },
-  {
-    id = "switch_bsp",
-    label = "Switch Build Server",
-    hint = "Switch to another available build server.",
-  },
-  {
-    id = "connect_build",
-    label = "Connect Build",
-    hint = "Connect to the current build server.",
-  },
-  {
-    id = "disconnect_build",
-    label = "Disconnect Build",
-    hint = "Disconnect from the current build server.",
-  },
-  {
-    id = "import_build",
-    label = "Import Build",
-    hint = "Import the current build.",
-  },
-  {
-    id = "restart_build",
-    label = "Restart Build",
-    hint = "Restart the current build server.",
+    hint = "Analyze stacktrace from clipboard.",
   },
   {
     id = "compile_cancel",
@@ -61,14 +26,19 @@ local commands_table = {
     hint = "Trigger a clean compile.",
   },
   {
+    id = "connect_build",
+    label = "Connect Build",
+    hint = "Connect to the current build server.",
+  },
+  {
     id = "copy_worksheet_output",
     label = "Copy Worksheet Output",
     hint = "Copy the evaluated worksheet output to your clipboard.",
   },
   {
-    id = "run_doctor",
-    label = "Run Doctor",
-    hint = "Run doctor.",
+    id = "disconnect_build",
+    label = "Disconnect Build",
+    hint = "Disconnect from the current build server.",
   },
   {
     id = "generate_bsp_config",
@@ -86,14 +56,9 @@ local commands_table = {
     hint = "Install Metals.",
   },
   {
-    id = "update",
-    label = "Update Metals",
-    hint = "Update to the latest Metals.",
-  },
-  {
-    id = "toggle_logs",
-    label = "Toggle Logs",
-    hint = "Toggle Metals logs.",
+    id = "import_build",
+    label = "Import Build",
+    hint = "Import the current build.",
   },
   {
     id = "new_scala_file",
@@ -121,9 +86,19 @@ local commands_table = {
     hint = "Reset a specific choice.",
   },
   {
+    id = "restart_build",
+    label = "Restart Build",
+    hint = "Restart the current build server.",
+  },
+  {
     id = "restart_server",
     label = "Restart Server",
     hint = "Restart Metals",
+  },
+  {
+    id = "run_doctor",
+    label = "Run Doctor",
+    hint = "Run doctor.",
   },
   {
     id = "scan_sources",
@@ -131,14 +106,39 @@ local commands_table = {
     hint = "Scan all workspace sources.",
   },
   {
+    id = "start_ammonite",
+    label = "Start Ammonite",
+    hint = "Start the Ammonite build server.",
+  },
+  {
     id = "start_server",
     label = "Start Server",
     hint = "Start Metals (only useful if you have it disabled by default).",
   },
   {
+    id = "stop_ammonite",
+    label = "Stop Ammonite",
+    hint = "Stop the Ammonite build server.",
+  },
+  {
     id = "super_method_hierarchy",
     label = "Super Method Hierarchy",
     hint = "Calculate inheritance hierarchy.",
+  },
+  {
+    id = "switch_bsp",
+    label = "Switch Build Server",
+    hint = "Switch to another available build server.",
+  },
+  {
+    id = "toggle_logs",
+    label = "Toggle Logs",
+    hint = "Toggle Metals logs.",
+  },
+  {
+    id = "update",
+    label = "Update Metals",
+    hint = "Update to the latest Metals.",
   },
 }
 

--- a/lua/metals/commands.lua
+++ b/lua/metals/commands.lua
@@ -6,12 +6,12 @@
 -- issue we wait.
 local commands_table = {
   {
-    id = "ammonite_start",
+    id = "start_ammonite",
     label = "Start Ammonite",
     hint = "Start the Ammonite build server.",
   },
   {
-    id = "ammonite_stop",
+    id = "stop_ammonite",
     label = "Stop Ammonite",
     hint = "Stop the Ammonite build server.",
   },
@@ -21,27 +21,27 @@ local commands_table = {
     hint = "Analyze stacktrace frop clipboard.",
   },
   {
-    id = "bsp_switch",
+    id = "switch_bsp",
     label = "Switch Build Server",
     hint = "Switch to another available build server.",
   },
   {
-    id = "build_connect",
+    id = "connect_build",
     label = "Connect Build",
     hint = "Connect to the current build server.",
   },
   {
-    id = "build_disconnect",
+    id = "disconnect_build",
     label = "Disconnect Build",
     hint = "Disconnect from the current build server.",
   },
   {
-    id = "build_import",
+    id = "import_build",
     label = "Import Build",
     hint = "Import the current build.",
   },
   {
-    id = "build_restart",
+    id = "restart_build",
     label = "Restart Build",
     hint = "Restart the current build server.",
   },
@@ -66,7 +66,7 @@ local commands_table = {
     hint = "Copy the evaluated worksheet output to your clipboard.",
   },
   {
-    id = "doctor_run",
+    id = "run_doctor",
     label = "Run Doctor",
     hint = "Run doctor.",
   },
@@ -91,7 +91,7 @@ local commands_table = {
     hint = "Update to the latest Metals.",
   },
   {
-    id = "logs_toggle",
+    id = "toggle_logs",
     label = "Toggle Logs",
     hint = "Toggle Metals logs.",
   },
@@ -126,7 +126,7 @@ local commands_table = {
     hint = "Restart Metals",
   },
   {
-    id = "sources_scan",
+    id = "scan_sources",
     label = "Scan Sources",
     hint = "Scan all workspace sources.",
   },

--- a/lua/metals/decoration.lua
+++ b/lua/metals/decoration.lua
@@ -21,7 +21,7 @@ M.store_hover_message = function(decoration)
   hover_messages[hover_line] = hover_message
 end
 
-M.worksheet_hover = function()
+M.hover_worksheet = function()
   local row, _ = unpack(api.nvim_win_get_cursor(0))
   local hover_message = hover_messages[row]
 

--- a/lua/metals/setup.lua
+++ b/lua/metals/setup.lua
@@ -16,8 +16,8 @@ local lsps = {}
 local metals_name = "metals"
 
 -- So by default metals starts automatically, however, if a user wants it not
--- to, then this needs to be set to true it order for Metals to continually
--- attatch in a workspace that MetalsServerStart was called on.
+-- to, then this needs to be set to true in order for Metals to continually
+-- attach in a workspace that MetalsStartServer was called on.
 local explicity_enabled = false
 
 local function in_disabled_mode()
@@ -321,7 +321,7 @@ end
 M.auto_commands = function()
   api.nvim_command([[augroup NvimMetals]])
   api.nvim_command([[autocmd!]])
-  api.nvim_command([[autocmd BufEnter * lua require'metals'.did_focus()]])
+  api.nvim_command([[autocmd BufEnter * lua require("metals").did_focus()]])
   api.nvim_command([[autocmd CursorHold  *.scala lua vim.lsp.buf.document_highlight()]])
   api.nvim_command([[autocmd CursorMoved *.scala lua vim.lsp.buf.clear_references()]])
   api.nvim_command([[autocmd BufEnter,CursorHold,InsertLeave *.scala lua vim.lsp.codelens.refresh()]])
@@ -351,7 +351,7 @@ M.setup_dap = function(execute_command)
         envFile = metals_dap_settings.envFile,
       },
     }, function(_, _, res)
-      -- In metals we throw various exceptions when hanlding
+      -- In metals we throw various exceptions when handling
       -- debug-adapter-start but they are all handled and status messages are
       -- given to the client, so they aren't errors here. That's why we don't
       -- really capture or care about the err and instead just make sure res is
@@ -365,7 +365,7 @@ M.setup_dap = function(execute_command)
           port = port,
           enrich_config = function(_config, on_config)
             local final_config = vim.deepcopy(_config)
-            -- Just incase strip this out since it's metals-specific
+            -- Just in case strip this out since it's metals-specific
             final_config.metals = nil
             on_config(final_config)
           end,


### PR DESCRIPTION
I was curious about neovim commands misalignment you mentioned on Twitch, so I decided to experiment.
Everything seems to work and looks now more mature.
What do you think about this change?
Changes:
- Fixed typo `luacheck`
- Fixed typo for `MetalLogToggle` ( missing `s` after Log ) ( changed later to `MetalsToggleLogs` )
- Fixed typo for `MetalsDoctor` in documentation and changed to `MetalsRunDoctor`
- Changed neovim Metals command in the way where the verb is followed by a noun
- Reflected commands changes in documentation
- checked format and lint
- Sorted metals telescope commands alphabetically
- Fixed `frop` typo in `analyze_stacktrace`
- Renamed `worksheet_hover` to `hover_worksheet` command
- Sorted Commands in docs
- Sorted LUA API commands in docs
- Added support for previous versions of commands ( errors for commands, for which it is impossible to show a warning, as it disappears; for example for `logs_toggle`. I've added warnings for commands which allow the message to be displayed while new command is being executed)