### PR TITLE
Add in ability to toggle boolean settings.

### DIFF
--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -657,9 +657,10 @@ initialize_or_attach({config})
 
   api.nvim_command [[augroup NvimMetals]]
   api.nvim_command [[autocmd!]]
-  api.nvim_command [[autocmd BufEnter <buffer> lua require("metals").did_focus()]]
+  api.nvim_command [[autocmd BufEnter * lua require("metals").did_focus()]]
   api.nvim_command [[autocmd CursorHold  <buffer> lua vim.lsp.buf.document_highlight()]]
   api.nvim_command [[autocmd CursorMoved <buffer> lua vim.lsp.buf.clear_references()]]
+  api.nvim_command([[autocmd BufEnter,CursorHold,InsertLeave <buffer> lua vim.lsp.codelens.refresh()]])
   api.nvim_command [[augroup end]]
 <
                           Notice that this adds in an autocmd for
@@ -752,6 +753,22 @@ switch_bsp()              Use to execute a |metals.bsp-switch| command.
 toggle_logs()             Use to trigger a |tail -f .metals/log| on your
                           current workspace that will open in the embedded
                           Neovim terminal.
+
+                                                              *toggle_setting()*
+toggle_setting({setting})
+
+                          Use to toggle a boolean setting in |metals-settings|.
+                          If the setting is not set, you'll be toggling it on.
+
+                          Parameters:
+                          {setting} (string) the name of the setting that
+                          you'd like to toggle.
+
+                          Example usage: >
+
+    lua require("metals").toggle_setting("showImplicitArguments")
+<
+
 
 ================================================================================
 METALS TVP MODULE                                            *metals-tvp-module*

--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -352,4 +352,20 @@ M.setup_dap = function()
   setup.setup_dap(execute_command)
 end
 
+M.toggle_setting = function(setting)
+  if not vim.tbl_contains(setup.metals_settings, setting) then
+    log.warn_and_show(string.format("%s is not a valid metals settings. Doing nothing.", setting))
+  elseif not type(setting) == "boolean" then
+    log.warn_and_show(string.format("%s is not a boolean setting. You can only toggle boolean settings", setting))
+  else
+    local settings = setup.settings
+    if settings[setting] == nil then
+      settings[setting] = true
+    else
+      settings[setting] = not settings[setting]
+    end
+    lsp.buf_notify(0, "workspace/didChangeConfiguration", { settings = { metals = settings } })
+  end
+end
+
 return M

--- a/lua/metals/setup.lua
+++ b/lua/metals/setup.lua
@@ -164,7 +164,7 @@ local metals_init_options = {
 }
 
 -- Currently available settings.
-local metals_settings = {
+M.metals_settings = {
   "ammoniteJvmProperties",
   "bloopSbtAlreadyInstalled",
   "bloopVersion",
@@ -292,9 +292,12 @@ M.initialize_or_attach = function(config)
 
   if config.settings then
     for k, _ in pairs(config.settings) do
-      if not vim.tbl_contains(metals_settings, k) then
+      if not vim.tbl_contains(M.metals_settings, k) then
         local heading = string.format('"%s" is not a valid setting. It will be ignored.', k)
-        local valid_settings = string.format("The following are valid settings %s", table.concat(metals_settings, ", "))
+        local valid_settings = string.format(
+          "The following are valid settings %s",
+          table.concat(M.metals_settings, ", ")
+        )
         local err = heading .. "\n" .. valid_settings
         log.warn_and_show(err)
       end


### PR DESCRIPTION
This will allow for a user to easily use a mapping to toggle a boolean
setting. Thinking about this a bit more, we can probably in the future
make a nice way to change any setting value and send that in. Something
that prompts the user for input, and then they can input the new value
and the same logic could be used to send in the notification to Metals.
But until we need that, this should be fine.

Closes #189

Pinging @stumash since you were the one to bring this up.