### PR TITLE
Remove the recommendation to Remove -F from shortmess.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,6 @@ integrations with other projects such as
     version of nvim, v.0.5.x.
 - Ensure [Coursier](https://get-coursier.io/docs/cli-installation) is installed
     on your machine. `nvim-metals` uses Coursier to download and update Metals.
-- Remove `F` from `shortmess`. `set shortmess-=F`
-    (for lua `vim.opt_global.shortmess:remove("F"):append("c")`)
-    _NOTE_: Without doing this,
-    autocommands that deal with filetypes prohibit messages from being shown...
-    and since we heavily rely on this, this _must_ be set.
 - Ensure that you have mappings created for functionality that you desire. By
     default methods for things like goto definition, find references, etc are
     there, but not automatically mapped. You can find a minimal example

--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -102,12 +102,6 @@ following: >
 If no version is set, it defaults to the latest stable release. If a new
 release comes out or you change your |g:metals_server_version|, you can
 simply issue a |MetalsUpdate| command.
-
-If you believe that you have everything configured correctly, but do not see
-the message about installing Metals, ensure that you have removed `F` from
-`shortmess`. After this you should be able to execute a |MetalsInfo| to see the
-installed Metals version, the location of the install, and also the location
-of the `nvim-metals.log` file.
 ================================================================================
 SETTINGS                                                       *metals-settings*
 


### PR DESCRIPTION
It used to be that the message requests weren't being shown with Neovim
without this being removed since our autocmd relies on a filetype.
However this seems to be working now without removing it both on nightly
and on 0.5.0 stable.

Fixes #193