### PR TITLE
Add in ability to specify serverProperties and also grab javaopts.

### DIFF
--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -143,6 +143,7 @@ All available settings:
   * |sbtScript|
   * |scalafixConfigPath|
   * |scalafmtConfigPath|
+  * |serverProperties|
   * |showImplicitArguments|
   * |showImplicitConversionsAndClasses|
   * |showInferredType|
@@ -320,6 +321,19 @@ Default: false ~
 
 When this option is enabled, each method that can have inferred types has them
 displayed as extra info in the hover.
+
+serverProperties                                              *serverProperties*
+
+Type: table ~
+Default: {} ~
+
+Table of properties to pass along to the Metals server. By default, the
+environment variable `JAVA_OPTS` and the `.jvmopts` file are respected.
+However, we care most about the proxy settings from those places, not
+necessarily the memory options since Metals has different requirements for
+example than sbt. So if you have proxy settings defined in `JAVA_OPTS`, then
+no need to define them here again. However, if you want to set some spefic
+memory settings for Metals, then this is the place. 
 
 superMethodLensesEnabled                              *superMethodLensesEnabled*
 

--- a/lua/metals/jvmopts.lua
+++ b/lua/metals/jvmopts.lua
@@ -1,0 +1,98 @@
+-- This file is taken from:
+-- https://github.com/ckipp01/nvim-jvmopts
+-- While there is a little but of duplication in here with other parts of the
+-- codebase, I'd rather just leave it fully intact since this is all tested in
+-- that repo.
+
+local uv = vim.loop
+
+local is_windows = uv.os_uname().version:match("Windows")
+local path_sep = is_windows and "\\" or "/"
+
+local function path_join(...)
+  local result = table.concat(vim.tbl_flatten({ ... }), path_sep):gsub(path_sep .. "+", path_sep)
+  return result
+end
+
+local function exists(filename)
+  local stat = uv.fs_stat(filename)
+  return stat and stat.type or false
+end
+
+local function merge_lists(a, b)
+  if b == nil then
+    if a == nil then
+      return {}
+    else
+      return a
+    end
+  else
+    local merged = vim.deepcopy(a)
+
+    for _, v in ipairs(b) do
+      if type(v) == "string" then
+        table.insert(merged, v)
+      end
+    end
+
+    return merged
+  end
+end
+
+local function parse_env_variable(variable)
+  local options = {}
+  if variable == nil then
+    return options
+  else
+    for substring in variable:gmatch("%S+") do
+      table.insert(options, substring)
+    end
+    return options
+  end
+end
+
+local function read_from_file(file)
+  if exists(file) then
+    local lines = {}
+    for line in io.lines(file) do
+      lines[#lines + 1] = line
+    end
+    return lines
+  else
+    return {}
+  end
+end
+
+local function java_opts_from_env()
+  return parse_env_variable(os.getenv("JAVA_OPTS"))
+end
+
+local function java_flags_from_env()
+  return parse_env_variable(os.getenv("JAVA_FLAGS"))
+end
+
+local function java_env()
+  return merge_lists(java_opts_from_env(), java_flags_from_env())
+end
+
+local function java_opts_from_file(workspace_root)
+  if workspace_root ~= nil then
+    local jvm_opts_file = path_join(workspace_root, ".jvmopts")
+    local lines = read_from_file(jvm_opts_file)
+    return lines
+  else
+    return {}
+  end
+end
+
+local function java_opts(workspace)
+  return merge_lists(java_env(), java_opts_from_file(workspace))
+end
+
+return {
+  java_env = java_env,
+  java_flags_from_env = java_flags_from_env,
+  java_opts = java_opts,
+  java_opts_from_env = java_opts_from_env,
+  java_opts_from_file = java_opts_from_file,
+}

--- a/lua/metals/util.lua
+++ b/lua/metals/util.lua
@@ -229,4 +229,28 @@ M.camel_to_pascal = function(s)
   return pascal_string
 end
 
+M.merge_lists = function(a, b)
+  if b == nil then
+    if a == nil then
+      return {}
+    else
+      return a
+    end
+  else
+    local merged = vim.deepcopy(a)
+
+    for _, v in ipairs(b) do
+      if type(v) == "string" then
+        table.insert(merged, v)
+      end
+    end
+
+    return merged
+  end
+end
+
+M.starts_with = function(text, prefix)
+  return text:find(prefix, 1, true) == 1
+end
+
 return M


### PR DESCRIPTION
Unlike some of the other Metals clients, up until this point it's been
pretty much impossible to set server properties for Metals. This change
adds in a new `serverProperties` setting that allows you to send in
properties that Metals will be started with.

This also uses https://github.com/ckipp01/nvim-jvmopts to grab the
values from the workspace `.jvmopts` file and also values from
`JAVA_OPTS` and `JAVA_FLAGS`. However, nvim-metals strips out most of
the settings from these if they are related to memory. Mainly because
the memory requirements you put in your workspace are more than likely
for sbt, not for metals. Instead use `serverProperties` for this. I do
this to align with coc-metals and the VS Code extension.