### PR TITLE
Revert commit about removing -F recommendation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ integrations with other projects such as
     version of nvim, v.0.5.x.
 - Ensure [Coursier](https://get-coursier.io/docs/cli-installation) is installed
     on your machine. `nvim-metals` uses Coursier to download and update Metals.
+- Remove `F` from `shortmess`. `set shortmess-=F`
+    (for lua `vim.opt_global.shortmess:remove("F")`)
+    _NOTE_: Without doing this, autocommands that deal with filetypes prohibit
+    messages from being shown, so some of the messages we show to help users get
+    started may not be shown. _If_ you're confident you don't need help setting
+    up, then just remove this, and `nvim-metals` will work fine, but any log
+    messages won't actually be shown to you if something goes wrong with
+    `nvim-metals`.
 - Ensure that you have mappings created for functionality that you desire. By
     default methods for things like goto definition, find references, etc are
     there, but not automatically mapped. You can find a minimal example

--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -41,6 +41,13 @@ PREREQUISITES                                             *metals-prerequisites*
   just let nvim-metals handle Metals.
 - https://get-coursier.io/ - Metals uses coursier to manage the installation
   and updating of Metals.
+- Remove `F` from `shortmess`. `set shortmess-=F` (for lua
+  `vim.opt_global.shortmess:remove("F")`) NOTE: Without doing this,
+  autocommands that deal with filetypes prohibit messages from being shown, so
+  some of the messages we show to help users get started may not be shown.
+  If you're confident you don't need help setting up, then just remove this,
+  and `nvim-metals` will work fine, but any log messages won't actually be
+  shown to you if something goes wrong with `nvim-metals`.
 - Make sure you have your mappings for various LSP functionality configured.
   Neovim provides functions for things like goto-definition, find references,
   etc, but they need to be mapped.


### PR DESCRIPTION
So the main reason we need this is because nvim-metals adds in some extra
logging and messages to help users get started. So for example say you try
to get started but haven't actually installed Metals, it will log and give instructions
to you about how to do that. However, without removing -F, this won't happen.
So you can remove this if you're confident you don't need it and everything
will work fine, you just might not get messages about things going wrong.

Closes #193 for real this time.