### PR TITLE
Set superMethodLensesEnabled to default to on.

### DIFF
--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -345,11 +345,10 @@ memory settings for Metals, then this is the place.
 superMethodLensesEnabled                              *superMethodLensesEnabled*
 
 Type: boolean ~
-Default: false ~
+Default: true ~
 
 When enabled Metals will populate code lenses for you to navigate to the
-parent/super methods of members. This is off by default since it is expensive
-to populate.
+parent/super methods of members.
 
 ================================================================================
 OPTIONS                                                         *metals-options*

--- a/lua/metals/setup.lua
+++ b/lua/metals/setup.lua
@@ -321,6 +321,11 @@ local function initialize_or_attach(config)
 
   settings.metals = config.settings or {}
 
+  -- We specifically want to enable this if a user has no preference on it.
+  if settings.metals.superMethodLensesEnabled == nil then
+    settings.metals.superMethodLensesEnabled = true
+  end
+
   -- Just so we can access these in the info command
   settings_cache = settings.metals
 


### PR DESCRIPTION
In the last release of metals there were some massive improvements
to the speed of this feature. This used to be turned off due to
performance issues, which we no longer need to worry about.