### PR TITLE
Fix display of diagnostic signs

### DIFF
--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -886,14 +886,14 @@ metals#status()           Able to be used in your statusline to show status
 
                                                                *metals#errors()*
 metals#errors()          Meant to be used with a statusline integration. This
-                         will re-use the existing |LspDiagnosticsErrorSign|
+                         will re-use the existing |LspDiagnosticsSignError|
                          and |lsp.util.buf_diagnostics_count("Error")| to
                          return a string of sign + count of errors in the
                          current buffer.
 
                                                              *metals#warnings()*
 metals#warnings()        Meant to be used with a statusline integration. This
-                         will re-use the existing |LspDiagnosticsWarningSign|
+                         will re-use the existing |LspDiagnosticsSignWarning|
                          and |lsp.util.buf_diagnostics_count("Warning")| to
                          return a string of sign + count of warnings in the
                          current buffer.

--- a/plugin/metals.vim
+++ b/plugin/metals.vim
@@ -8,7 +8,7 @@ endfunction
 
 function! metals#errors() abort
   let errorCount = luaeval("vim.lsp.diagnostic.get_count(vim.fn.bufnr('%'), [[Error]])")
-  let possibleLspSign = sign_getdefined("LspDiagnosticsErrorSign")
+  let possibleLspSign = sign_getdefined("LspDiagnosticsSignError")
   let sign = get(possibleLspSign, 0, {"text": "E"})
   if (errorCount > 0)
     return sign.text . errorCount
@@ -19,7 +19,7 @@ endfunction
 
 function! metals#warnings() abort
   let warningCount = luaeval("vim.lsp.diagnostic.get_count(vim.fn.bufnr('%'), [[Warning]])")
-  let possibleLspSign = sign_getdefined("LspDiagnosticsWarningSign")
+  let possibleLspSign = sign_getdefined("LspDiagnosticsSignWarning")
   let sign = get(possibleLspSign, 0, {"text": "W"})
   if (warningCount > 0)
     return sign.text . warningCount


### PR DESCRIPTION
The naming layout for the diagnostic signs has changed:
https://github.com/neovim/neovim/pull/12655
