### PR TITLE
Ensure bare_config can set compilerOptions.

### DIFF
--- a/lua/metals/setup.lua
+++ b/lua/metals/setup.lua
@@ -155,7 +155,7 @@ end
 -- A bare config to use to be passed into initialize_or_attach.
 -- This is meant only to be used when a user is editing anything in the config
 -- just to ensure they don' thave to do a couple manual initialization of tables
-local bare_config = { handlers = {}, init_options = {}, settings = {}, tvp = {} }
+local bare_config = { handlers = {}, init_options = { compilerOptions = {} }, settings = {}, tvp = {} }
 
 local metals_init_options = {
   compilerOptions = { snippetAutoIndent = false },


### PR DESCRIPTION
This just ensures that users can correctly set compilerOptions in the
initializationOptions that are sent to Metals. I guess no one uses these
ha, since this could never have worked before unless they user would set
it to `{}` first and then set the value they were wanting. However, I'm
assuming that's never been done. I realized this while looking at
https://github.com/scalameta/metals-feature-requests/issues/235