### PR TITLE
Ensure an empty config can still be used

### DIFF
--- a/lua/metals/setup.lua
+++ b/lua/metals/setup.lua
@@ -348,7 +348,12 @@ local function initialize_or_attach(config)
     end
   end
 
-  local passed_in_options = config.settings.serverProperties or {}
+  local passed_in_options = {}
+
+  if config.settings and config.settings.serverProperties then
+    passed_in_options = config.settings.serverProperties
+  end
+
   local all_opts = util.merge_lists(passed_in_options, valid_java_opts)
 
   for i, opt in ipairs(all_opts) do


### PR DESCRIPTION
When we added in the new settings for serverProperties we forgot
to add a check for them and sort of just assumed that everyone would
be starting with the bare_config. However, that's not the case, and this
fails if you just pass in `{}`.

Closes #242