### PR TITLE
Simplify config cache and make bare_config a function.

### DIFF
--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -91,7 +91,7 @@ bar somehow. This can be achieved by just accessing it with Lua via
 status messages and feedback that you will get will be much less. You can
 enable the `statusBarProvider` like shown below: >
 
-  metals_config = require("metals").bare_config
+  metals_config = require("metals").bare_config()
   metals_config.init_options.statusBarProvider = "on"
 <
 
@@ -118,7 +118,7 @@ The following settings are able to be passed along with the config table to
 in a setting that is not a valid Metals setting. You can set these like the
 example below shows: >
 
-  metals_config = require("metals").bare_config
+  metals_config = require("metals").bare_config()
   metals_config.settings = {
     showImplicitArguments = true,
     excludePackages = {
@@ -634,10 +634,12 @@ That's why nvim-metals lua commands sometimes differ from metals commands.
                                                           *analyze_stacktrace()*
 analyze_stacktrace()      Use to execute a |metals.analyze-stacktrace| command.
 
-                                                                   *bare_config*
-bare_config
-                          An empty config table with empty tables also set for
-                          settings, handlers, and init_options.
+                                                                 *bare_config()*
+bare_config()
+                          Returns an empty config table with empty tables also
+                          set for settings, handlers, and init_options, and
+                          tvp settings. Use this when setting ups settings for
+                          `nvim-metals` to pass into |initialize_or_attach()|.
 
                                                               *compile_cancel()*
 compile_cancel()          Use to execute a |metals.compile-cancel| command.

--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -131,7 +131,7 @@ M.info = function()
       table.insert(output, s)
     end
 
-    local settings = conf.get_settings_cache()
+    local settings = conf.get_config_cache().settings.metals
     if settings then
       table.insert(output, "")
       table.insert(output, "## Current settings")
@@ -371,12 +371,18 @@ M.toggle_setting = function(setting)
   elseif not type(setting) == "boolean" then
     log.warn_and_show(string.format("%s is not a boolean setting. You can only toggle boolean settings", setting))
   else
-    local settings = conf.get_settings_cache()
+    local message
+    local settings = conf.get_config_cache().settings.metals
     if settings[setting] == nil then
+      message = string.format("Enabled %s", setting)
       settings[setting] = true
     else
+      local new_setting = not settings[setting]
+      message = string.format("%s is now %s", setting, new_setting)
       settings[setting] = not settings[setting]
     end
+    log.info_and_show(message)
+
     lsp.buf_notify(0, "workspace/didChangeConfiguration", { settings = { metals = settings } })
   end
 end

--- a/lua/metals/setup.lua
+++ b/lua/metals/setup.lua
@@ -116,7 +116,9 @@ end
 -- A bare config to use to be passed into initialize_or_attach.
 -- This is meant only to be used when a user is editing anything in the config
 -- just to ensure they don' thave to do a couple manual initialization of tables
-local bare_config = { handlers = {}, init_options = { compilerOptions = {} }, settings = {}, tvp = {} }
+local function bare_config()
+  return { handlers = {}, init_options = { compilerOptions = {} }, settings = {}, tvp = {} }
+end
 
 local function add_commands()
   for _, cmd in pairs(commands_table) do

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -22,22 +22,26 @@ end
 describe("config", function()
   local current_buf = api.nvim_get_current_buf()
   local config = require("metals.config")
+
   before_each(function()
     package.loaded["metals.config"] = nil
     config = require("metals.config")
   end)
+
   it("should handle an empty table", function()
     local valid_config = config.validate_config({}, current_buf)
     base_asserts(valid_config)
   end)
+
   it("should handle a bare config", function()
-    local bare_config = require("metals.setup").bare_config
+    local bare_config = require("metals.setup").bare_config()
 
     local valid_config = config.validate_config(bare_config, current_buf)
     base_asserts(valid_config)
   end)
+
   it("should persist the config in cache", function()
-    local bare_config = require("metals.setup").bare_config
+    local bare_config = require("metals.setup").bare_config()
     bare_config.settings = {
       showImplicitArguments = true,
     }
@@ -49,5 +53,14 @@ describe("config", function()
     local cache = config.get_config_cache()
 
     eq(valid_config, cache)
+  end)
+
+  it("should strip out java_opts we don't want", function()
+    local bare_config = require("metals.setup").bare_config()
+    bare_config.settings.serverProperties = { "-Xmx", "XsomeCoolThing" }
+
+    local valid_config = config.validate_config(bare_config, current_buf)
+
+    eq(#valid_config.cmd, 3)
   end)
 end)


### PR DESCRIPTION
*NOTE* This commit contains a breaking change.

Previously when you were setting up your config table to pass into
`initialize_or_attach()` you'd start by creating a bare config like
this:

```lua
Metals_config = require("metals").bare_config
```

The problem with this was that the `bare_config` was just a table that
by you setting values to was actually mutating the `bare_config` table
internally. Since we'd like to keep that as a fresh bare config this
has been migrated to instead be a function that returns a bare config.
This means that where you are using `bare_config` you'll now want to
call it like so:

```lua
Metals_config = require("metals").bare_config()
```

Also, please subscribe to this discussion:
https://github.com/scalameta/nvim-metals/discussions/253

All breaking changes will be listed there.