### PR TITLE
Add option to override find_root_dir function

### DIFF
--- a/lua/metals/config.lua
+++ b/lua/metals/config.lua
@@ -128,7 +128,9 @@ local function validate_config(config, bufnr)
 
   local bufname = api.nvim_buf_get_name(bufnr)
 
-  config.root_dir = util.find_root_dir(config.root_patterns, bufname) or fn.expand("%:p:h")
+  local find_root_dir = config.find_root_dir or util.find_root_dir
+
+  config.root_dir = find_root_dir(config.root_patterns, bufname) or fn.expand("%:p:h")
 
   local base_handlers = vim.tbl_extend("error", default_handlers, tvp.handlers)
 


### PR DESCRIPTION
This new function is part of the config table passed into
`initialize_or_attach()`. For example:

```lua
metals_config = require("metals").bare_config()
metals_config.find_root_dir = function(patterns, startpath)
  -- insert your functionality here...
end
```

The `patterns` argument is `metals_config.root_patterns`, and the
`startpath` argument is the path to the current buffer. The return value
of this function sets the `root_dir` parameter of the LSP client
configuration table. See `:help vim.lsp.start_client` for more
information.

Resolves #257.