### PR TITLE
Add test for detecting root dir when non root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 doc/tags
 mill-minimal/
 multiple-build-file-example/
+minimal-scala-cli-test/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,9 @@ You can find the tests that exist for `nvim-metals` in the `tests/` directory.
 These are ran using the
 [`plenary.test_harness`](https://github.com/nvim-lua/plenary.nvim/tree/master#plenarytest_harness).
 It's useful to give the plenary page a read about this to better understand what
-is happening, but to run the tests you'll just need to `make test`.
+is happening. However, before running the tests make sure to run `make
+test-setup` which will clone some repos used for testing. After this you can
+simply use `make test`.
 
 ## Other Libraries / Integrations
 

--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,7 @@ test:
 test-all:
 	nvim --headless --noplugin -u tests/minimal.vim -c "PlenaryBustedDirectory tests/ { minimal_init = 'tests/minimal.vim' }"
 
-
+clean:
+	rm -rf mill-minimal
+	rm -rf minimal-scala-cli-test
+	rm -rf multiple-build-file-example

--- a/lua/metals/rootdir.lua
+++ b/lua/metals/rootdir.lua
@@ -6,7 +6,7 @@ local has_pattern = function(patterns, target)
   for _, pattern in ipairs(patterns) do
     local what_we_are_looking_for = Path:new(target, pattern)
     if what_we_are_looking_for:exists() then
-      return true
+      return pattern
     end
   end
 end
@@ -23,9 +23,14 @@ local find_root_dir = function(patterns, startpath)
   local path = Path:new(startpath)
   -- TODO if we don't find it do we really want to search / probably not... add a check for this
   for _, parent in ipairs(path:parents()) do
-    if has_pattern(patterns, parent) then
+    local pattern = has_pattern(patterns, parent)
+    if pattern then
       local grandparent = Path:new(parent):parent()
-      if has_pattern(patterns, grandparent) then
+      -- If the pattern is found, we don't check for all patterns anymore,
+      -- instead only the one that was found. This will ensure that we don't
+      -- find a buid.sc is src/build.sc and also a .git in ./ causing it to
+      -- default to that instead of src for the root.
+      if has_pattern({ pattern }, grandparent) then
         return grandparent.filename
       else
         return parent

--- a/tests/setup/clone_spec.lua
+++ b/tests/setup/clone_spec.lua
@@ -1,0 +1,36 @@
+local Path = require("plenary.path")
+local Job = require("plenary.job")
+
+local multi_build_example = Path:new("multiple-build-file-example/")
+local mill_minimal = Path:new("mill-minimal/")
+local scala_cli = Path:new("minimal-scala-cli-test/")
+
+-- Not really a test at all, but we run this as a spec so it's picked up during
+-- make test-setup and clones the expected repos down before we make test
+local clone = function(repo)
+  Job
+    :new({
+      command = "git",
+      args = { "clone", repo },
+      on_exit = function(_, status)
+        if not status == 0 then
+          print("Something went wrong cloning")
+        else
+          print("Correctly cloned")
+        end
+      end,
+    })
+    :start()
+end
+
+if not (multi_build_example:exists()) then
+  clone("https://github.com/ckipp01/multiple-build-file-example.git")
+end
+
+if not (mill_minimal:exists()) then
+  clone("https://github.com/ckipp01/mill-minimal.git")
+end
+
+if not (scala_cli:exists()) then
+  clone("https://github.com/ckipp01/minimal-scala-cli-test.git")
+end

--- a/tests/setup/clone_spec.lua
+++ b/tests/setup/clone_spec.lua
@@ -19,6 +19,9 @@ local clone = function(repo)
           print("Correctly cloned")
         end
       end,
+      on_start = function()
+        print("starting to clone " .. repo)
+      end,
     })
     :start()
 end
@@ -33,4 +36,17 @@ end
 
 if not (scala_cli:exists()) then
   clone("https://github.com/ckipp01/minimal-scala-cli-test.git")
+end
+
+-- what exactly is this? honestly I don't know, but if we do the repeat 500
+-- times, that should be more than enough to clone these down, so if we
+-- hit that fail.
+local count = 0
+while not (multi_build_example:exists()) or not (mill_minimal:exists()) or not (scala_cli:exists()) do
+  if count == 500 then
+    print("Something went wrong when trying to clone.")
+    return
+  end
+  count = count + 1
+  print("waiting for clones to finish...")
 end

--- a/tests/tests/root_dir_spec.lua
+++ b/tests/tests/root_dir_spec.lua
@@ -7,6 +7,7 @@ local Job = require("plenary.job")
 
 local multi_build_example = Path:new("multiple-build-file-example/")
 local mill_minimal = Path:new("mill-minimal/")
+local scala_cli = Path:new("minimal-scala-cli-test/")
 
 local clone = function(repo)
   Job
@@ -32,6 +33,10 @@ if not (mill_minimal:exists()) then
   clone("https://github.com/ckipp01/mill-minimal.git")
 end
 
+if not (scala_cli:exists()) then
+  clone("https://github.com/ckipp01/minimal-scala-cli-test.git")
+end
+
 describe("The find root dir functionality", function()
   it("should correctly fall back to the cwd if no build file", function()
     eq(root_dir.find_root_dir({ "build.sbt" }, Path:new()._absolute), Path:new()._absolute)
@@ -51,6 +56,15 @@ describe("The find root dir functionality", function()
     eq(
       root_dir.find_root_dir({ "build.sc" }, Path:new(mill_minimal, "MillMinimal", "src", "example", "Hello.scala")),
       mill_minimal._absolute
+    )
+  end)
+
+  -- .scala is a root pattern meaning src here should be the root, not the root
+  -- of the directorty that contains the .git
+  it("should correct pick up pattern instead of the .git root", function()
+    eq(
+      root_dir.find_root_dir({ ".scala", ".git" }, Path:new(scala_cli, "src", "Main.scala")),
+      Path:new(scala_cli, "src")._absolute
     )
   end)
 end)


### PR DESCRIPTION
Interesting, this fails when you give it both `.scala` and `.git`, but not if you give it `.git`. Something odd with the ordering is going on here I assume.