### PR TITLE
Correct packer.nvim syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ it.
 example if using [`packer`](https://github.com/wbthomason/packer.nvim):
 
 ```lua
-use({'scalameta/nvim-metals'}, requires = { "nvim-lua/plenary.nvim" })
+use{'scalameta/nvim-metals', requires = { "nvim-lua/plenary.nvim" }}
 ```
 
 ## Getting started


### PR DESCRIPTION
In lua there are no named arguments, this is simulated by the fact that when passing a table or string literal, the parenthesis can be omitted. `use` expects a table with its first value being the direction of the extension, and among other optional fields, a table in the key `requires` with the directions of the extensions required. 

In the notes, it shows as if `use` takes two arguments, a table with the direction of the first extension and then a named argument with a table with the direction of the first extension.