### PR TITLE
fix: update arguments to be sent in with super method commands.

### DIFF
--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -423,6 +423,7 @@ The following commands are provided by nvim-metals:
   * |MetalsDisconnectBuild|
   * |MetalsFindInDependencyJars|
   * |MetalsGenerateBspConfig|
+  * |MetalsGotoSuperMethod|
   * |MetalsImportBuild|
   * |MetalsInstall|
   * |MetalsInfo|
@@ -499,6 +500,9 @@ MetalsGenerateBspConfig      Checks to see if your build tool can serve as a
                              to generate the config. After the config is 
                              generated, Metals will attempt to auto-connect to
                              it.
+
+                                                         *MetalsGotoSuperMethod*
+MetalsGotoSuperMethod       Jump to the super method of the current symbol.
 
                                                              *MetalsImportBuild*
 MetalsImportBuild            Trigger an import for the current workspace.
@@ -675,6 +679,11 @@ disconnect_build()        Use to execute a |metals.build-disconnect| command.
 
                                                          *generate_bsp_config()*
 generate_bsp_config()     Use to execute a |metals.generate-bsp-config| command.
+
+                                                           *goto_super_method()*
+goto_super_method()       Use to execute a |metals.goto-super-method| command.
+                          This is the same as triggering the code lens on a
+                          symbol that is overriding another.
 
                                                      *find_in_dependency_jars()*
 find_in_dependency_jars() Use to send in a `meatls/findTextInDependencyJars`

--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -344,12 +344,19 @@ M.start_server = function()
   setup.initialize_or_attach()
 end
 
+M.goto_super_method = function()
+  local text_doc_position = lsp.util.make_position_params()
+  execute_command({
+    command = "metals.goto-super-method",
+    arguments = { text_doc_position },
+  })
+end
+
 M.super_method_hierarchy = function()
-  local uri = vim.uri_from_bufnr(0)
   local text_doc_position = lsp.util.make_position_params()
   execute_command({
     command = "metals.super-method-hierarchy",
-    arguments = { { document = uri, position = text_doc_position.position } },
+    arguments = { text_doc_position },
   })
 end
 

--- a/lua/metals/commands.lua
+++ b/lua/metals/commands.lua
@@ -51,6 +51,11 @@ local commands_table = {
     hint = "Generate the BSP config for your build tool.",
   },
   {
+    id = "goto_super_method",
+    label = "Goto Super Method",
+    hint = "Goto the super method of this symbol.",
+  },
+  {
     id = "import_build",
     label = "Import Build",
     hint = "Import the current build.",


### PR DESCRIPTION
This is to go along with https://github.com/scalameta/metals/pull/3284
since in the last release the arguments needed for these commands
changed from the customer ones to just use `TextDocumentPositionParams`.