### PR TITLE
Add in disabledMode and useGlobalExecutable settings to the config table

### DIFF
--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -11,12 +11,11 @@ CONTENTS                                                           *nvim-metals*
     1. Prerequisites........ |metals-prerequisites|
     2. Getting Started...... |metals-getting-started|
     3. Settings............. |metals-settings|
-    4. Options.............. |metals-options|
-    5. Commands............. |metals-commands|
-    6. LUA API.............. |metals-lua-api|
-    7. TVP Module........... |metals-tvp-module|
-    8. Custom Handlers...... |metals-custom-handlers|
-    9. Integrations......... |metals-integrations|
+    4. Commands............. |metals-commands|
+    5. LUA API.............. |metals-lua-api|
+    6. TVP Module........... |metals-tvp-module|
+    7. Custom Handlers...... |metals-custom-handlers|
+    8. Integrations......... |metals-integrations|
 
 ================================================================================
 INTRODUCTION                                                *metals-introduction*
@@ -166,9 +165,11 @@ _ones that are sent and used by the server_
   * |superMethodLensesEnabled|
   *
 _ones that are used internally by `nvim-metals`_ 
+  * |disabledMode|
   * |decorationColor|
   * |serverOrg|
   * |serverVersion|
+  * |useGlobalExecutable|
 
 
 ammoniteJvmProperties                                    *ammoniteJvmProperties*
@@ -207,6 +208,21 @@ Default: 'Conceal' ~
 The highlight group that will be used to show decorations. For example, this
 will change the way worksheet evaluations are displayed in `*.worksheet.sc`
 file.
+
+                                                                  *disabledMode*
+Type: boolean ~
+Default: false ~
+
+Used in the situation where you don't want Metals to start by default when you
+enter a Scala workspace. WARNING: Use this with caution though as it may be
+confusing why Metals isn't starting when you're in a workspace and you forgot
+you have this set. If using this, once you'd like to use Metals in a specific
+workspace you'll need to manually start the server via |MetalsStartServer| or
+via a mapping with |start_server()|. Then it will continue to work in that
+workspace until you close it. NOTE: The choice isn't persisted, so you need to
+continually do this every time you want to use it even in the same workspace.
+If people _actually_ use this setting and want that, submit a feature request,
+if not it's not worth the extra work.
 
 excludedPackages                                              *excludedPackages*
 
@@ -388,27 +404,7 @@ Default: true ~
 When enabled Metals will populate code lenses for you to navigate to the
 parent/super methods of members.
 
-================================================================================
-OPTIONS                                                         *metals-options*
-
-The following options are provided by `nvim-metals`.
-
-                                                        *g:metals_disabled_mode*
-Type: boolean ~
-Default: false ~
-
-Used in the situation where you don't want Metals to start by default when you
-enter a Scala workspace. WARNING: Use this with caution though as it may be
-confusing why Metals isn't starting when you're in a workspace and you forgot
-you have this set. If using this, once you'd like to use Metals in a specific
-workspace you'll need to manually start the server via |MetalsStartServer| or
-via a mapping with |start_server()|. Then it will continue to work in that
-workspace until you close it. NOTE: The choice isn't persisted, so you need to
-continually do this every time you want to use it even in the same workspace.
-If people _actually_ use this setting and want that, submit a feature request,
-if not it's not worth the extra work.
-
-                                                *g:metals_use_global_executable*
+                                                           *useGlobalExecutable*
 Type: boolean ~
 Default: false ~
 

--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -121,7 +121,11 @@ end
 -- Capture info about the currently installed Metals and display it in a
 -- floating window.
 M.info = function()
-  if not util.has_bins(conf.metals_bin()) and vim.g.metals_use_global_executable then
+  local config = conf.get_config_cache()
+  if
+    not util.has_bins(conf.metals_bin())
+    and (config.settings.metals.useGlobalExecutable or vim.g.metals_use_global_executable)
+  then
     log.error_and_show(messages.use_global_set_but_cant_find)
   elseif not util.has_bins(conf.metals_bin()) then
     log.warn_and_show(messages.metals_not_installed)
@@ -133,11 +137,10 @@ M.info = function()
       table.insert(output, s)
     end
 
-    local settings = conf.get_config_cache().settings.metals
-    if settings then
+    if config.settings.metals then
       table.insert(output, "")
       table.insert(output, "## Current settings")
-      for s in vim.inspect(settings):gmatch("[^\r\n]+") do
+      for s in vim.inspect(config.settings.metals):gmatch("[^\r\n]+") do
         table.insert(output, s)
       end
     end
@@ -146,7 +149,7 @@ M.info = function()
     table.insert(output, string.format("  - nvim-metals log file: %s", log.nvim_metals_log))
     table.insert(output, string.format("  - nvim lsp log file: %s", Path:new(fn.stdpath("cache"), "lsp.log").filename))
     local loc_msg = "  - metals install location:"
-    if vim.g.metals_use_global_executable then
+    if config.settings.metals.useGlobalExecutable or vim.g.metals_use_global_executable then
       table.insert(output, string.format("%s %s", loc_msg, "Using metals executable on $PATH"))
     else
       table.insert(output, string.format("%s %s", loc_msg, conf.metals_bin()))
@@ -338,7 +341,12 @@ M.show_javap_verbose = function()
 end
 
 M.start_server = function()
-  if vim.g.metals_disabled_mode then
+  local config = conf.get_config_cache()
+  if
+    config.settings.disabledMode
+    or (config.settings.metals and config.settings.metals.disabledMode)
+    or vim.g.metals_disabled_mode
+  then
     setup.explicitly_enable()
   end
   setup.initialize_or_attach()

--- a/lua/metals/install.lua
+++ b/lua/metals/install.lua
@@ -10,12 +10,13 @@ local Job = require("plenary.job")
 -- executes `:MetalsInstall` it will just install the latest or install what they
 -- have set no matter what. If there is an exesiting Metals there, it is simply
 -- overwritten by the bootstrap command.
--- NOTE: that if a user has g:metals_use_global_executable set, this will just
--- throw an error at them since they can't use this in that case.
+-- NOTE: that if a user has useGlobalExecutable set, this will just throw an
+-- error at them since they can't use this in that case.
 -- @param sync (boolean) really only used for testing. If you are running test-setup
 -- then set this to true, else just let it be.
 local function install_or_update(sync)
-  if vim.g.metals_use_global_executable then
+  local config = conf.get_config_cache()
+  if config.settings.metals.useGlobalExecutable or vim.g.metals_use_global_executable then
     log.error_and_show(messages.use_global_set_so_cant_update)
     return true
   end
@@ -25,8 +26,6 @@ local function install_or_update(sync)
     log.error_and_show(messages.coursier_installed)
     return true
   end
-
-  local config = conf.get_config_cache()
 
   local server_version = "latest.release"
 

--- a/lua/metals/messages.lua
+++ b/lua/metals/messages.lua
@@ -20,19 +20,19 @@ You need to install Metals first before using `:MetalsInfo`.
 To install, use `:MetalsInstall`]]
 
 M.use_global_set_but_cant_find = [[
-You have `g:metals_use_global_executable` set to true, but nvim-metals is unable
-to find your executable Metals. Make sure `metals` is on your $PATH. If you
-want nvim-metals to install Metals for you, remove the
-`g:metals_use_global_executable` setting.]]
+You have `useGlobalExecutable` set to true, but nvim-metals is unable to find
+your executable Metals. Make sure `metals` is on your $PATH. If you want
+nvim-metals to install Metals for you, remove the `useGlobalExecutable`
+setting.]]
 
 M.use_global_set_so_cant_update = [[
-You have `g:metals_use_global` set to true, so nvim-metals can't install or
+You have `useGlobalExecutable` set to true, so nvim-metals can't install or
 update your Metals executable. If you'd like nvim-metals to handle this for
-you, remove the `g:metals_use_global_executable` setting and try again.]]
+you, remove the `useGlobalExecutable` setting and try again.]]
 
 M.server_version_setting_deprecated = [[
-Setting the server version via vim.g.metals_server_version is deprecated, please use config settings instead.
-]]
+Setting the server version via vim.g.metals_server_version is deprecated,
+please use config settings instead.]]
 
 M.cant_use_snapshot_setting_with_custom_org = [[
 Cannont use the SNAPSHOT feature with another server org.

--- a/lua/metals/setup.lua
+++ b/lua/metals/setup.lua
@@ -13,8 +13,16 @@ local lsps = {}
 -- attach in a workspace that MetalsStartServer was called on.
 local explicity_enabled = false
 
-local function in_disabled_mode()
-  if vim.g.metals_disabled_mode and not explicity_enabled then
+local function in_disabled_mode(config)
+  -- TODO make a function in config that can just check if disabledMode is set
+  -- instead of this madness
+  if
+    (
+      (config.settings and config.settings.disabledMode)
+      or (config.settings and config.settings.metals and config.settings.metals.disabledMode)
+      or vim.g.metals_disabled_mode
+    ) and not explicity_enabled
+  then
     return true
   else
     return false
@@ -74,7 +82,7 @@ local function initialize_or_attach(config)
   -- disabled mode.
   add_commands()
 
-  if in_disabled_mode() then
+  if in_disabled_mode(config) then
     conf.set_config_cache(config)
     return
   end


### PR DESCRIPTION

This is now the preferred way to set these instead of using the
`g:metals_use_global_executable` and `g:metals_disabled_mode` options.

Closes #234