### PR TITLE
Update all the things for 0.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     name: Run tests
     strategy:
       matrix:
-        neovim_branch: ['v0.5.0', 'master']
+        neovim_branch: ['v0.6.0', 'master']
     runs-on: ubuntu-latest
     env:
       NEOVIM_BRANCH: ${{ matrix.neovim_branch }}

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 # nvim-metals
 
-nvim-metals is a Lua plugin built to provide a better experience while using
+`nvim-metals` is a Lua plugin built to provide a better experience while using
 Metals, the Scala Language Server, with Neovim's built-in [LSP
 support](https://neovim.io/doc/user/lsp.html). This plugin provides the
 necessary commands you'll need to develop with nvim and Metals. This extension
-also implements many of the custom Metals LSP extensions that will give you a
-much richer experience than just using Metals with the default
+also implements the custom Metals LSP extensions that will give you a much
+richer experience than just using Metals with the default
 [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) setup, as well as
 automatically setting all of the correct `init_options`, and offering some
 integrations with other projects such as
@@ -25,7 +25,8 @@ integrations with other projects such as
 
 ## Prerequisites
 
-- Before you get started you need to ensure that you are using nvim >= v.0.5.0.
+- Before you get started you need to ensure that you are using nvim v.0.6.0 or
+    newer.
 - Ensure [Coursier](https://get-coursier.io/docs/cli-installation) is installed
     on your machine. `nvim-metals` uses Coursier to download and update Metals.
 - Remove `F` from `shortmess`. `set shortmess-=F`
@@ -61,7 +62,8 @@ it.
 example if using [`packer`](https://github.com/wbthomason/packer.nvim):
 
 ```lua
-use{'scalameta/nvim-metals', requires = { "nvim-lua/plenary.nvim" }}
+use({'scalameta/nvim-metals', requires = { "nvim-lua/plenary.nvim" }})
+
 ```
 
 ## Getting started

--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -31,9 +31,9 @@ the correct `init_options`.
 ================================================================================
 PREREQUISITES                                             *metals-prerequisites*
 
-- Ensure you're using at least Neovim v0.5.0. While `nvim-metals`
-  will aim to always work with the latest stable version of Neovim, there is
-  not guarantee of compatibility with older versions.
+- Ensure you're using at least Neovim v0.6.0. While `nvim-metals` will aim to
+  always work with the latest stable version of Neovim, there is no guarantee
+  of compatibility with older versions.
 - *DO NOT* use this plugin for Metals and also `neovim/nvim-lspconfig` for
   Metals. If you've used `neovim/nvim-lspconfig` before with Metals, make sure
   to remove metals setup for it as it will conflict with this plugin.  NOTE:

--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -243,16 +243,31 @@ M.did_focus = function()
 end
 
 M.find_in_dependency_jars = function()
-  local mask = fn.input("File mask: ", ".conf")
-  local query = vim.fn.input("Query: ")
-  if not query or #query == 0 then
-    return
-  else
+  local function send_request(mask, query)
     lsp.buf_request(0, "metals/findTextInDependencyJars", {
       options = { include = mask },
       query = { pattern = query },
     })
   end
+
+  local function get_query_and_send(mask)
+    vim.ui.input({
+      prompt = "Query: ",
+    }, function(query)
+      if query ~= nil then
+        send_request(mask, query)
+      end
+    end)
+  end
+
+  vim.ui.input({
+    prompt = "File mask: ",
+    default = ".conf",
+  }, function(mask)
+    if mask ~= nil then
+      get_query_and_send(mask)
+    end
+  end)
 end
 
 M.organize_imports = function()

--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -25,18 +25,13 @@ local M = {}
 -- @param command_params (optional, table) Parameters to send to the server (arguments and command).
 -- @param callback (function) callback function for the request response.
 local function execute_command(command_params, callback)
-  lsp.buf_request(
-    0,
-    "workspace/executeCommand",
-    command_params,
-    util.lsp_handler(function(err, result, ctx)
-      if callback then
-        callback(err, ctx.method, result)
-      elseif err then
-        log.error_and_show(string.format("Could not execute command: %s", err.message))
-      end
-    end)
-  )
+  lsp.buf_request(0, "workspace/executeCommand", command_params, function(err, result, ctx)
+    if callback then
+      callback(err, ctx.method, result)
+    elseif err then
+      log.error_and_show(string.format("Could not execute command: %s", err.message))
+    end
+  end)
 end
 
 M.analyze_stacktrace = function()

--- a/lua/metals/handlers.lua
+++ b/lua/metals/handlers.lua
@@ -14,7 +14,7 @@ local decoration_namespace = api.nvim_create_namespace("metals_decoration")
 
 -- Implementation of the `metals/quickPick` Metals LSP extension.
 -- - https://scalameta.org/metals/docs/integrations/new-editor.html#metalsquickpick
-M["metals/quickPick"] = util.lsp_handler(function(_, result)
+M["metals/quickPick"] = function(_, result)
   local opts = {
     format_item = function(item)
       return item.label
@@ -32,11 +32,11 @@ M["metals/quickPick"] = util.lsp_handler(function(_, result)
 
   vim.ui.select(result.items, opts, cb)
   return choice
-end)
+end
 
 -- Implementation of the `metals/inputBox` Metals LSP extension.
 -- - https://scalameta.org/metals/docs/integrations/new-editor.html#metalsinputbox
-M["metals/inputBox"] = util.lsp_handler(function(_, result)
+M["metals/inputBox"] = function(_, result)
   local response = { cancelled = true }
 
   vim.ui.input({
@@ -48,11 +48,11 @@ M["metals/inputBox"] = util.lsp_handler(function(_, result)
   end)
 
   return response
-end)
+end
 
 -- Implementation of the `metals/executeClientCommand` Metals LSP extension.
 -- - https://scalameta.org/metals/docs/integrations/new-editor.html#metalsexecuteclientcommand
-M["metals/executeClientCommand"] = util.lsp_handler(function(_, result)
+M["metals/executeClientCommand"] = function(_, result)
   if result.command == "metals-goto-location" then
     lsp.util.jump_to_location(result.arguments[1])
   elseif result.command == "metals-doctor-run" then
@@ -69,24 +69,24 @@ M["metals/executeClientCommand"] = util.lsp_handler(function(_, result)
   else
     log.warn_and_show(string.format("Looks like nvim-metals doesn't handle %s yet.", result.command))
   end
-end)
+end
 
 -- Callback function to handle `metals/status`
 -- This simply sets a global variable `metals_status` which can be easily
 -- picked up and used in a statusline.
 -- Command and Tooltip are not covered from the spec.
 -- - https://scalameta.org/metals/docs/editors/new-editor.html#metalsstatus
-M["metals/status"] = util.lsp_handler(function(_, result)
+M["metals/status"] = function(_, result)
   if result.hide then
     util.metals_status()
   else
     util.metals_status(result.text)
   end
-end)
+end
 
 -- Function needed to implement the Decoration Protocol from Metals.
 -- - https://scalameta.org/metals/docs/integrations/decoration-protocol.html
-M["metals/publishDecorations"] = util.lsp_handler(function(err, result)
+M["metals/publishDecorations"] = function(err, result)
   if err then
     log.error_and_show("Server error while publishing decorations. Please see logs for details.")
     log.error(err.message)
@@ -115,9 +115,9 @@ M["metals/publishDecorations"] = util.lsp_handler(function(err, result)
     decoration.set_decoration(bufnr, decoration_namespace, deco)
     decoration.store_hover_message(deco)
   end
-end)
+end
 
-M["metals/findTextInDependencyJars"] = util.lsp_handler(function(_, result, ctx, config)
+M["metals/findTextInDependencyJars"] = function(_, result, ctx, config)
   if not result or vim.tbl_isempty(result) then
     vim.notify("Nothing found in jars files.")
   else
@@ -136,6 +136,6 @@ M["metals/findTextInDependencyJars"] = util.lsp_handler(function(_, result, ctx,
       api.nvim_command("copen")
     end
   end
-end)
+end
 
 return M

--- a/lua/metals/handlers.lua
+++ b/lua/metals/handlers.lua
@@ -33,13 +33,17 @@ end)
 -- Implementation of the `metals/inputBox` Metals LSP extension.
 -- - https://scalameta.org/metals/docs/integrations/new-editor.html#metalsinputbox
 M["metals/inputBox"] = util.lsp_handler(function(_, result)
-  local name = vim.fn.input(result.prompt .. ": ")
+  local response = { cancelled = true }
 
-  if name == "" then
-    return { cancelled = true }
-  else
-    return { value = name }
-  end
+  vim.ui.input({
+    prompt = result.prompt .. ": ",
+  }, function(input)
+    if input ~= nil then
+      response = { value = input }
+    end
+  end)
+
+  return response
 end)
 
 -- Implementation of the `metals/executeClientCommand` Metals LSP extension.

--- a/lua/metals/handlers.lua
+++ b/lua/metals/handlers.lua
@@ -15,39 +15,30 @@ local decoration_namespace = api.nvim_create_namespace("metals_decoration")
 -- Implementation of the `metals/quickPick` Metals LSP extension.
 -- - https://scalameta.org/metals/docs/integrations/new-editor.html#metalsquickpick
 M["metals/quickPick"] = function(_, result)
-  local opts = {
-    format_item = function(item)
-      return item.label
-    end,
-    prompt = result.placeHolder,
-  }
-
-  local choice = { cancelled = true }
-
-  local cb = function(item, _)
-    if item ~= nil then
-      choice = { itemId = item.id }
-    end
+  local ids = {}
+  local labels = {}
+  for i, item in pairs(result.items) do
+    table.insert(ids, item.id)
+    table.insert(labels, i .. " - " .. item.label)
   end
-
-  vim.ui.select(result.items, opts, cb)
-  return choice
+  local choice = vim.fn.inputlist(labels)
+  if choice == 0 then
+    return { cancelled = true }
+  else
+    return { itemId = ids[choice] }
+  end
 end
 
 -- Implementation of the `metals/inputBox` Metals LSP extension.
 -- - https://scalameta.org/metals/docs/integrations/new-editor.html#metalsinputbox
 M["metals/inputBox"] = function(_, result)
-  local response = { cancelled = true }
+  local name = vim.fn.input(result.prompt .. ": ")
 
-  vim.ui.input({
-    prompt = result.prompt .. ": ",
-  }, function(input)
-    if input ~= nil then
-      response = { value = input }
-    end
-  end)
-
-  return response
+  if name == "" then
+    return { cancelled = true }
+  else
+    return { value = name }
+  end
 end
 
 -- Implementation of the `metals/executeClientCommand` Metals LSP extension.

--- a/lua/metals/handlers.lua
+++ b/lua/metals/handlers.lua
@@ -15,19 +15,23 @@ local decoration_namespace = api.nvim_create_namespace("metals_decoration")
 -- Implementation of the `metals/quickPick` Metals LSP extension.
 -- - https://scalameta.org/metals/docs/integrations/new-editor.html#metalsquickpick
 M["metals/quickPick"] = util.lsp_handler(function(_, result)
-  local ids = {}
-  local labels = {}
-  for i, item in pairs(result.items) do
-    table.insert(ids, item.id)
-    table.insert(labels, i .. " - " .. item.label)
+  local opts = {
+    format_item = function(item)
+      return item.label
+    end,
+    prompt = result.placeHolder,
+  }
+
+  local choice = { cancelled = true }
+
+  local cb = function(item, _)
+    if item ~= nil then
+      choice = { itemId = item.id }
+    end
   end
 
-  local choice = vim.fn.inputlist(labels)
-  if choice == 0 then
-    return { cancelled = true }
-  else
-    return { itemId = ids[choice] }
-  end
+  vim.ui.select(result.items, opts, cb)
+  return choice
 end)
 
 -- Implementation of the `metals/inputBox` Metals LSP extension.

--- a/lua/metals/tvp/init.lua
+++ b/lua/metals/tvp/init.lua
@@ -141,65 +141,60 @@ function Tree:tree_view_children(opts)
   if opts.parent_uri ~= nil then
     tree_view_children_params["nodeUri"] = opts.parent_uri
   end
-  vim.lsp.buf_request(
-    valid_metals_buffer(),
-    "metals/treeViewChildren",
-    tree_view_children_params,
-    util.lsp_handler(function(err, result)
-      if err then
-        log.error(err)
-        log.error_and_show("Something went wrong while requesting tvp children. More info in logs.")
+  vim.lsp.buf_request(valid_metals_buffer(), "metals/treeViewChildren", tree_view_children_params, function(err, result)
+    if err then
+      log.error(err)
+      log.error_and_show("Something went wrong while requesting tvp children. More info in logs.")
+    else
+      local new_nodes = {}
+      for _, node in pairs(result.nodes) do
+        table.insert(new_nodes, Node:new(node))
+      end
+      if opts.parent_uri == nil then
+        self.children = new_nodes
       else
-        local new_nodes = {}
-        for _, node in pairs(result.nodes) do
-          table.insert(new_nodes, Node:new(node))
+        self:update(opts.parent_uri, new_nodes)
+      end
+      -- NOTE: Not ideal to have to iterate over these again, but we want the
+      -- update to happen before we call this or else we'll have issues adding the
+      -- children to a node that doesn't yet exist.
+      for _, node in pairs(new_nodes) do
+        if node.collapse_state == collapse_state.expanded then
+          self:tree_view_children({ view_id = metals_packages, parent_uri = node.node_uri })
         end
-        if opts.parent_uri == nil then
-          self.children = new_nodes
-        else
-          self:update(opts.parent_uri, new_nodes)
+      end
+      if opts.expand then
+        local node = self:find(opts.parent_uri)
+        if node and node.collapse_state and node.collapse_state == collapse_state.collapsed then
+          node:expand(valid_metals_buffer())
         end
-        -- NOTE: Not ideal to have to iterate over these again, but we want the
-        -- update to happen before we call this or else we'll have issues adding the
-        -- children to a node that doesn't yet exist.
-        for _, node in pairs(new_nodes) do
-          if node.collapse_state == collapse_state.expanded then
-            self:tree_view_children({ view_id = metals_packages, parent_uri = node.node_uri })
-          end
+      end
+      local additionals = opts.additionals
+      if additionals then
+        local head = table.remove(additionals, 1)
+        local additional_params = {
+          view_id = view_id,
+          parent_uri = head,
+          expand = opts.expand,
+          focus = opts.focus,
+        }
+        if #additionals > 1 then
+          additional_params.additionals = additionals
         end
-        if opts.expand then
-          local node = self:find(opts.parent_uri)
-          if node and node.collapse_state and node.collapse_state == collapse_state.collapsed then
-            node:expand(valid_metals_buffer())
-          end
-        end
-        local additionals = opts.additionals
-        if additionals then
-          local head = table.remove(additionals, 1)
-          local additional_params = {
-            view_id = view_id,
-            parent_uri = head,
-            expand = opts.expand,
-            focus = opts.focus,
-          }
-          if #additionals > 1 then
-            additional_params.additionals = additionals
-          end
-          self:tree_view_children(additional_params)
-        end
+        self:tree_view_children(additional_params)
+      end
 
-        self:reload_and_show()
-        if opts.focus and not opts.additionals then
-          for line, node in pairs(self.lookup) do
-            if node.node_uri == opts.parent_uri then
-              api.nvim_win_set_cursor(self.win_id, { line, 0 })
-              break
-            end
+      self:reload_and_show()
+      if opts.focus and not opts.additionals then
+        for line, node in pairs(self.lookup) do
+          if node.node_uri == opts.parent_uri then
+            api.nvim_win_set_cursor(self.win_id, { line, 0 })
+            break
           end
         end
       end
-    end)
-  )
+    end
+  end)
 end
 
 function Tree:cache()
@@ -357,7 +352,7 @@ function Tree:find(uri)
   return found_node
 end
 
-handlers["metals/treeViewDidChange"] = util.lsp_handler(function(_, result)
+handlers["metals/treeViewDidChange"] = function(_, result)
   if not state.tvp_tree then
     Tree:new():cache()
   else
@@ -376,7 +371,7 @@ handlers["metals/treeViewDidChange"] = util.lsp_handler(function(_, result)
       end
     end
   end
-end)
+end
 
 local function ensure_tree_exists_then(fn)
   if not state.tvp_tree then
@@ -408,35 +403,30 @@ local function reveal_in_tree()
     end
     local params = lsp.util.make_position_params()
 
-    vim.lsp.buf_request(
-      valid_metals_buffer(),
-      "metals/treeViewReveal",
-      params,
-      util.lsp_handler(function(err, result, ctx)
-        if err then
-          log.error_and_show(string.format("Unable to execute command: %s.", ctx.method))
-        else
-          if result and result.viewId == metals_packages then
-            if api.nvim_get_current_win() ~= state.tvp_tree.win_id then
-              vim.fn.win_gotoid(state.tvp_tree.win_id)
-            end
-
-            util.reverse(result.uriChain)
-            local head = table.remove(result.uriChain, 1)
-
-            state.tvp_tree:tree_view_children({
-              view_id = result.viewId,
-              parent_uri = head,
-              additionals = result.uriChain,
-              expand = true,
-              focus = true,
-            })
-          else
-            log.warn_and_show("You recieved a node for a view nvim-metals doesn't support")
+    vim.lsp.buf_request(valid_metals_buffer(), "metals/treeViewReveal", params, function(err, result, ctx)
+      if err then
+        log.error_and_show(string.format("Unable to execute command: %s.", ctx.method))
+      else
+        if result and result.viewId == metals_packages then
+          if api.nvim_get_current_win() ~= state.tvp_tree.win_id then
+            vim.fn.win_gotoid(state.tvp_tree.win_id)
           end
+
+          util.reverse(result.uriChain)
+          local head = table.remove(result.uriChain, 1)
+
+          state.tvp_tree:tree_view_children({
+            view_id = result.viewId,
+            parent_uri = head,
+            additionals = result.uriChain,
+            expand = true,
+            focus = true,
+          })
+        else
+          log.warn_and_show("You recieved a node for a view nvim-metals doesn't support")
         end
-      end)
-    )
+      end
+    end)
   end)
 end
 

--- a/lua/metals/util.lua
+++ b/lua/metals/util.lua
@@ -112,25 +112,4 @@ M.starts_with = function(text, prefix)
   return text:find(prefix, 1, true) == 1
 end
 
--- Create an lsp handler compatible with the new handler signature and the old
--- https://github.com/neovim/neovim/pull/15504/
--- @param func function
--- @return function
-function M.lsp_handler(fn)
-  return function(...)
-    local config_or_client_id = select(4, ...)
-    local is_new = type(config_or_client_id) ~= "number"
-    if is_new then
-      return fn(...)
-    else
-      local err = select(1, ...)
-      local method = select(2, ...)
-      local result = select(3, ...)
-      local client_id = select(4, ...)
-      local bufnr = select(5, ...)
-      local config = select(6, ...)
-      return fn(err, result, { method = method, client_id = client_id, bufnr = bufnr }, config)
-    end
-  end
-end
 return M


### PR DESCRIPTION
NOTE: That when this pr is merged, 0.6 will be the new required default for `nvim-metals`.

- [x] `vim.fn.input` -> `vim.ui.input`
- [ ] `vim.fn.inputlist` -> `vim.ui.select` (NOTE: We won't be able to use this.)
- [x] Remove the handler wrapper that makes both 0.5 and 0.6 handers work
- [x] Update docs to make sure people know 0.6 is the new required version

So we ended up not being able to use `vim.ui.select` where I thought we'd be able to. It's not recommended to use it in places were a return value is needed since it's call back based. The tricky part is that the default implementation in core is blocking, so it will work here, but then when you using an async plugin like telescope, it won't work. Since it's not safe to use that there we don't use it. Same goes with `vim.ui.input` in places where a return values us needed, like in a LSP server request.