### PR TITLE
feat: bump initialize_timeout_sec to 10

### DIFF
--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -1024,8 +1024,8 @@ The following run types are valid for Metals.
   - `runOrTestFile` (if there is a main method in the current file, it will
     run it or if there are tests in the file, run those)
 
-Below you can see an example of 3 configurations, one for each of the run
-types. >
+Below you can see an example of configurations, one for running or testing the
+current file and the other for testing the entire target. >
 
   local dap = require("dap")
 
@@ -1033,17 +1033,9 @@ types. >
     {
       type = "scala",
       request = "launch",
-      name = "Run",
+      name = "Run or Test Target",
       metals = {
-        runType = "run",
-      },
-    },
-    {
-      type = "scala",
-      request = "launch",
-      name = "Test File",
-      metals = {
-        runType = "testFile",
+        runType = "runOrTestFile",
       },
     },
     {
@@ -1052,14 +1044,6 @@ types. >
       name = "Test Target",
       metals = {
         runType = "testTarget",
-      },
-    },
-    {
-      type = "scala",
-      request = "launch",
-      name = "Run or Test Target",
-      metals = {
-        runType = "runOrTestFile",
       },
     },
   }

--- a/lua/metals/setup.lua
+++ b/lua/metals/setup.lua
@@ -143,6 +143,10 @@ local function setup_dap(execute_command)
           type = "server",
           host = "127.0.0.1",
           port = port,
+          options = {
+            -- The default in nvim-dap is 4, which is too short for Metals.
+            initialize_timeout_sec = 10,
+          },
           enrich_config = function(_config, on_config)
             local final_config = vim.deepcopy(_config)
             -- Just in case strip this out since it's metals-specific


### PR DESCRIPTION
Thanks to https://github.com/mfussenegger/nvim-dap/pull/376 the timeout
can now be customized. The default in nvim-dap is 4 seconds, which is
just too short with Metals. This will avoid the warning being shown all
the time. This isn't configurable for the time being, but if it needs to
be in the future it can be.