### PR TITLE
Fix Windows path, support .bat files

### DIFF
--- a/lua/metals/config.lua
+++ b/lua/metals/config.lua
@@ -42,12 +42,9 @@ local function in_disabled_mode(config)
   return disabled
 end
 
---- Ultimately what will be passed to the config.cmd to initialize the LSP
---- connection. If a user is using useGlobalExecutable then we just default
---- to `metals`, if not we take control and construct the location in the
---- cache dir.
---- @return string executable
-local function metals_bin()
+--- Used to generate Metals installation file name depending on configuration
+--- @return string fileame
+local function metals_filename()
   if (config_cache and config_cache.settings.metals.useGlobalExecutable) or vim.g.metals_use_global_executable then
     return metals_name
   else
@@ -55,11 +52,35 @@ local function metals_bin()
   end
 end
 
+--- Ultimately what will be passed to the config.cmd to initialize the LSP
+--- connection. If a user is using useGlobalExecutable then we just default
+--- to `metals`, if not we take control and construct the location in the
+--- cache dir.
+--- @return string executable
+local function metals_bin()
+  local metals_filename = metals_name
+  -- Coursier will install both a "metals" and "metals.bat", on Windows we should use "metals.bat" as exe
+  local metals_win_filename = metals_name .. ".bat"
+
+  if util.has_bins(metals_win_filename) then
+    metals_filename = metals_win_filename
+  end
+
+  if (config_cache and config_cache.settings.metals.useGlobalExecutable) or vim.g.metals_use_global_executable then
+    return metals_filename
+  else
+    return Path:new(util.nvim_metals_cache_dir, metals_filename).filename
+  end
+end
+
 --- Check to see if coursier is installed. This method favors the native cs. So if
 --- cs is installed, that will be returned, if not, then coursier will be returned.
 --- @return string 'cs', 'coursier', or nil
 local function check_for_coursier()
-  if util.has_bins("cs") then
+  -- this must be first the second "cs" is also found as binary but we should be more specific on Windows
+  if util.has_bins("cs.bat") then
+    return "cs.bat"
+  elseif util.has_bins("cs") then
     return "cs"
   elseif util.has_bins("coursier") then
     return "coursier"
@@ -284,6 +305,7 @@ return {
   in_disabled_mode = in_disabled_mode,
   get_config_cache = get_config_cache,
   metals_bin = metals_bin,
+  metals_filename = metals_filename,
   metals_init_options = metals_init_options,
   scala_file_types = scala_file_types,
   set_config_cache = set_config_cache,

--- a/lua/metals/install.lua
+++ b/lua/metals/install.lua
@@ -55,7 +55,7 @@ local function install_or_update(sync)
     "-r",
     "sonatype:snapshots",
     "-o",
-    conf.metals_bin(),
+    conf.metals_filename(),
     "-f",
   }
 


### PR DESCRIPTION
I propose a small fix for now, it will check if both `metals.bat` and `cs.bat` are on the path and uses them. It should work.
Both metals and coursier execs should be configurable and have different default values on win/linux. 