### PR TITLE
fix: remove usage of lsp.util.close_preview_autocmd()

### DIFF
--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -170,7 +170,6 @@ M.info = function()
     api.nvim_win_set_option(float.win_id, "winhl", "NormalFloat:Normal")
     api.nvim_win_set_option(float.border_win_id, "winhl", "NormalFloat:Normal")
     api.nvim_buf_set_lines(float.bufnr, 0, -1, false, output)
-    lsp.util.close_preview_autocmd({ "BufHidden", "BufLeave" }, float.win_id)
   end
 end
 

--- a/lua/metals/decoration.lua
+++ b/lua/metals/decoration.lua
@@ -29,9 +29,7 @@ M.hover_worksheet = function()
     return
   end
 
-  local _, winnr = lsp.util.open_floating_preview(hover_message, "markdown", { pad_left = 1, pad_right = 1 })
-
-  lsp.util.close_preview_autocmd({ "CursorMoved", "BufHidden", "InsertCharPre" }, winnr)
+  lsp.util.open_floating_preview(hover_message, "markdown", { pad_left = 1, pad_right = 1 })
 end
 
 M.clear_hover_messages = function()

--- a/lua/metals/doctor.lua
+++ b/lua/metals/doctor.lua
@@ -86,7 +86,6 @@ Doctor.create = function(args)
   api.nvim_buf_set_option(float.bufnr, "filetype", "markdown")
   api.nvim_buf_set_lines(float.bufnr, 0, -1, false, output)
   doctor_win_id = float.win_id
-  vim.lsp.util.close_preview_autocmd({ "BufHidden", "BufLeave" }, float.win_id)
 end
 
 return Doctor


### PR DESCRIPTION
This was removed on HEAD. Seems to work exactly the same without it both
on HEAD and also 0.6.0