### PR TITLE
fix: fix the quick worksheet command

### DIFF
--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -238,7 +238,7 @@ end
 M.quick_worksheet = function()
   local dir = "file://" .. fn.expand("%:p:h")
   local name = fn.expand("%:p:h:t")
-  M.new_scala_file(dir, name, "worksheet")
+  M.new_scala_file(dir, name, "scala-worksheet")
 end
 
 M.scan_sources = function()


### PR DESCRIPTION
This changed upstream and is no longer worksheet but scala-worksheet.

Closes #311 

I'll probably wait to merge this as it will break for users that aren't on nightly.