### PR TITLE
Improves Coursier setup documentation and error reporting on Windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ integrations with other projects such as
     newer.
 - Ensure [Coursier](https://get-coursier.io/docs/cli-installation) is installed
     on your machine. `nvim-metals` uses Coursier to download and update Metals.
+    _NOTE_: On Windows, you should run `coursier` or `cs.exe` once from the command
+    line as this is how it will install itself. Once this is done you should 
+    add `C:\Users\YOURNAME\AppData\Coursier\data\bin` to your path. To verify
+    that it is properly installed you can run `cs --help` from a new shell.
 - Remove `F` from `shortmess`. `set shortmess-=F`
     (for lua `vim.opt_global.shortmess:remove("F")`)
     _NOTE_: Without doing this, autocommands that deal with filetypes prohibit

--- a/lua/metals/config.lua
+++ b/lua/metals/config.lua
@@ -75,7 +75,13 @@ end
 local function check_for_coursier()
   -- this must be first the second "cs" is also found as binary but we should be more specific on Windows
   if util.is_windows then
-    return "cs.bat"
+    if util.has_bins("cs.bat") then
+      return "cs.bat"
+    else
+      log.error_and_show("Warning:Could not find cs.bat in PATH")
+      log.error_and_show("Installation instructions for Coursier https://get-coursier.io/docs/cli-installation#windows")
+      log.error_and_show("Make sure to run cs.exe once to install Coursier and add C:/Users/YOURNAME/AppData/Coursier/data/bin to your path.")
+    end
   else
     if util.has_bins("cs") then
       return "cs"

--- a/lua/metals/config.lua
+++ b/lua/metals/config.lua
@@ -78,9 +78,7 @@ local function check_for_coursier()
     if util.has_bins("cs.bat") then
       return "cs.bat"
     else
-      log.error_and_show("Warning:Could not find cs.bat in PATH")
-      log.error_and_show("Installation instructions for Coursier https://get-coursier.io/docs/cli-installation#windows")
-      log.error_and_show("Make sure to run cs.exe once to install Coursier and add C:/Users/YOURNAME/AppData/Coursier/data/bin to your path.")
+      log.error_and_show(messages.coursier_not_installed_windows)
     end
   else
     if util.has_bins("cs") then

--- a/lua/metals/messages.lua
+++ b/lua/metals/messages.lua
@@ -6,6 +6,12 @@ It looks like you don't have Coursier installed, which you need to install Metal
 
 You can find instructions on how to install it here: https://get-coursier.io/docs/cli-installation]]
 
+M.coursier_not_installed_windows = [[
+Warning: Could not find cs.bat in PATH
+You can find instructions on how to install it here: https://get-coursier.io/docs/cli-installation#windows
+Make sure to run cs.exe once to install Coursier and add it's installation directory to your path.
+See the note in the Readme.]]
+
 -- TODO figure out a way to just prompt this and do the install
 M.install_message = [[
 It looks like you don't have Metals installed yet.


### PR DESCRIPTION
Hi here is my quick fix for the problem I reported 2 days ago in https://github.com/scalameta/nvim-metals/pull/297.
I could not see the backslashes in the path in the error message so I left it with normal slashes. 