### PR TITLE
Explicitly pass character offset encoding to `apply_workspace_edit`

### DIFF
--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -311,7 +311,7 @@ M.organize_imports = function()
   for _, response in pairs(resp) do
     for _, result in pairs(response.result or {}) do
       if result.edit then
-        lsp.util.apply_workspace_edit(result.edit, 'utf-16')
+        lsp.util.apply_workspace_edit(result.edit, "utf-16")
       else
         lsp.buf.execute_command(result.command)
       end
@@ -349,7 +349,11 @@ local function show_decoded(decoder_type, format)
   execute_command({
     command = decoder.command,
     arguments = { metals_uri },
-  }, decoder.make_handler(file_uri, decoder_type, format))
+  }, decoder.make_handler(
+    file_uri,
+    decoder_type,
+    format
+  ))
 end
 
 M.show_tasty = function()

--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -311,7 +311,7 @@ M.organize_imports = function()
   for _, response in pairs(resp) do
     for _, result in pairs(response.result or {}) do
       if result.edit then
-        lsp.util.apply_workspace_edit(result.edit)
+        lsp.util.apply_workspace_edit(result.edit, 'utf-16')
       else
         lsp.buf.execute_command(result.command)
       end

--- a/lua/metals/handlers.lua
+++ b/lua/metals/handlers.lua
@@ -44,7 +44,7 @@ end
 -- - https://scalameta.org/metals/docs/integrations/new-editor.html#metalsexecuteclientcommand
 M["metals/executeClientCommand"] = function(_, result)
   if result.command == "metals-goto-location" then
-    lsp.util.jump_to_location(result.arguments[1])
+    lsp.util.jump_to_location(result.arguments[1], "utf-16")
   elseif result.command == "metals-doctor-run" then
     local args = fn.json_decode(result.arguments[1])
     doctor.create(args)


### PR DESCRIPTION
  this fixes the `MetalsOrganizeImport` command in neovim nightly.
  
  Here is the corresponding breaking change announcement: https://github.com/neovim/neovim/issues/14090#issuecomment-1012005684 