### PR TITLE
feat: Add in functionality to get build target info.

### DIFF
--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -352,6 +352,38 @@ local function show_decoded(decoder_type, format)
   }, decoder.make_handler(file_uri, decoder_type, format))
 end
 
+M.show_build_target_info = function()
+  local choose_and_decode = function(err, method, resp)
+    if err then
+      log.error_and_show(string.format("Unable to retrieve build targets", method))
+      log.error(err)
+    elseif resp then
+      vim.ui.select(resp, {
+        prompt = "Choose build target to view:",
+      }, function(choice)
+        if choice ~= nil then
+          local root = conf.get_config_cache().root_dir
+
+          local metals_uri = string.format(
+            "%s:file:///%s/%s.%s",
+            decoder.metals_decode,
+            root,
+            choice,
+            decoder.types.build_target
+          )
+          execute_command({
+            command = decoder.command,
+            arguments = { metals_uri },
+          }, decoder.make_handler(root, decoder.types.build_target))
+        end
+      end)
+    else
+      log.warn_and_show("Metals returned no info for build target.")
+    end
+  end
+  execute_command({ command = "metals.list-build-targets" }, choose_and_decode)
+end
+
 M.show_tasty = function()
   show_decoded(decoder.types.tasty, decoder.formats.decoded)
 end

--- a/lua/metals/commands.lua
+++ b/lua/metals/commands.lua
@@ -123,6 +123,11 @@ local commands_table = {
     hint = "Scan all workspace sources.",
   },
   {
+    id = "show_build_target_info",
+    label = "Show build target info",
+    hint = "Show the info of a specific build target.",
+  },
+  {
     id = "show_cfr",
     label = "Show decompiled with cfr",
     hint = "Show file decompiled with cfr.",

--- a/lua/metals/decoder.lua
+++ b/lua/metals/decoder.lua
@@ -5,6 +5,22 @@ local log = require("metals.log")
 local util = require("metals.util")
 local Path = require("plenary.path")
 
+local formats = {
+  compact = "compact",
+  decoded = "decoded",
+  detailed = "detailed",
+  proto = "proto",
+  verbose = "verbose",
+}
+
+local types = {
+  build_target = "metals-buildtarget",
+  cfr = "cfr",
+  javap = "javap",
+  semanticdb = "semanticdb",
+  tasty = "tasty",
+}
+
 local function filename_from_uri(full_uri)
   local parts = util.split_on(full_uri, "/")
   return parts[#parts]
@@ -52,8 +68,10 @@ local handle_decoder_response = function(result, uri, decoder, format)
       api.nvim_buf_set_name(new_buffer, name)
       -- TODO we should probably do something better for this case, but java is
       -- a bit nicer syntax for these than scala
-      if decoder == "javap" then
+      if decoder == types.javap then
         api.nvim_buf_set_option(new_buffer, "syntax", "java")
+      elseif decoder == types.build_target then
+        api.nvim_buf_set_option(new_buffer, "syntax", "txt")
       else
         api.nvim_buf_set_option(new_buffer, "syntax", "scala")
       end
@@ -77,20 +95,9 @@ end
 
 return {
   command = "metals.file-decode",
-  formats = {
-    compact = "compact",
-    decoded = "decoded",
-    detailed = "detailed",
-    proto = "proto",
-    verbose = "verbose",
-  },
+  formats = formats,
   handle_decoder_response = handle_decoder_response,
   make_handler = make_handler,
   metals_decode = "metalsDecode",
-  types = {
-    cfr = "cfr",
-    javap = "javap",
-    semanticdb = "semanticdb",
-    tasty = "tasty",
-  },
+  types = types,
 }


### PR DESCRIPTION
This uses the new `list-build-targets` that is going to be introduced in
https://github.com/scalameta/metals/pull/3649. This might change a bit
yet, but this is roughly what will be needed to use this.

![2022-02-18 19 08 13](https://user-images.githubusercontent.com/13974112/154739149-33e278ff-e9a1-47a6-b263-4366de3f3996.gif)

