### PR TITLE
feat: support new 2.13 artifacts

### DIFF
--- a/lua/metals/install.lua
+++ b/lua/metals/install.lua
@@ -26,7 +26,14 @@ local function install_or_update(sync)
     return true
   end
 
-  local server_version = config.settings.metals.serverVersion or "latest.release"
+  local latestStable = "latest.release"
+  local server_version = config.settings.metals.serverVersion or latestStable
+  local binary_version = "2.12"
+  -- TODO When we release 0.11.3 we need to change this to:
+  -- if server_version == latestStable or server_version > "0.11.2" then
+  if server_version ~= latestStable and server_version > "0.11.2" then
+    binary_version = "2.13"
+  end
 
   local server_org = config.settings.metals.serverOrg or "org.scalameta"
 
@@ -42,7 +49,7 @@ local function install_or_update(sync)
     "-Xss4m",
     "--java-opt",
     "-Xms100m",
-    string.format("%s:metals_2.12:%s", server_org, server_version),
+    string.format("%s:metals_%s:%s", server_org, binary_version, server_version),
     "-r",
     "bintray:scalacenter/releases",
     "-r",

--- a/tests/setup/install_spec.lua
+++ b/tests/setup/install_spec.lua
@@ -22,9 +22,19 @@ describe("install", function()
     eq(path:exists(), true)
   end)
 
-  it("should be able to install with a snapshot", function()
+  it("should be able to install with an old 2.12 snapshot", function()
     local bare_config = require("metals.setup").bare_config()
     bare_config.settings = { serverVersion = "0.10.9+131-30f6a57b-SNAPSHOT" }
+    config.validate_config(bare_config, vim.api.nvim_get_current_buf())
+
+    eq(path:exists(), false)
+    install.install_or_update(true)
+    eq(path:exists(), true)
+  end)
+
+  it("should be able to install with a new 2.13 snapshot", function()
+    local bare_config = require("metals.setup").bare_config()
+    bare_config.settings = { serverVersion = "0.11.2+3-105f3501-SNAPSHOT" }
     config.validate_config(bare_config, vim.api.nvim_get_current_buf())
 
     eq(path:exists(), false)


### PR DESCRIPTION
As of https://github.com/scalameta/metals/pull/3631 we now have 2.13 artifacts instead of 2.12.