### PR TITLE
feat: take into account tooltip and command in metals/status

### DIFF
--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -183,29 +183,7 @@ M.info = function()
   end
 end
 
-M.toggle_logs = function()
-  local bufs = api.nvim_list_bufs()
-
-  for _, buf in ipairs(bufs) do
-    local buftype = api.nvim_buf_get_option(buf, "buftype")
-    local _, purpose = pcall(api.nvim_buf_get_var, buf, "metals_buf_purpose")
-
-    if buftype == "terminal" and purpose == "logs" then
-      local first_window_id = fn.win_findbuf(buf)[1]
-      if first_window_id then
-        fn.win_gotoid(first_window_id)
-      else
-        api.nvim_command(string.format("vsp | :b %i", buf))
-      end
-
-      return
-    end
-  end
-
-  -- Only open them if a terminal isn't already open
-  api.nvim_command([[vsp +set\ ft=log term://tail -f .metals/metals.log]])
-  vim.b["metals_buf_purpose"] = "logs"
-end
+M.toggle_logs = conf.toggle_logs
 
 -- https://scalameta.org/metals/docs/integrations/new-editor/#create-new-scala-file
 -- https://scalameta.org/metals/docs/integrations/new-editor/#create-new-java-file

--- a/lua/metals/config.lua
+++ b/lua/metals/config.lua
@@ -4,7 +4,6 @@ local lsp = vim.lsp
 
 local decoration = require("metals.decoration")
 local default_handlers = require("metals.handlers")
-local doctor = require("metals.doctor")
 local jvmopts = require("metals.jvmopts")
 local log = require("metals.log")
 local messages = require("metals.messages")

--- a/lua/metals/install.lua
+++ b/lua/metals/install.lua
@@ -1,6 +1,7 @@
 local conf = require("metals.config")
 local log = require("metals.log")
 local messages = require("metals.messages")
+local status = require("metals.status")
 local util = require("metals.util")
 
 local Job = require("plenary.job")
@@ -41,7 +42,7 @@ local function install_or_update(sync)
     util.nvim_metals_cache_dir:mkdir()
   end
 
-  util.metals_status("Installing Metals...")
+  status.set_status("Installing Metals...")
 
   local args = {
     "bootstrap",
@@ -64,25 +65,25 @@ local function install_or_update(sync)
     args = args,
     on_exit = vim.schedule_wrap(function(_, exit)
       if exit == 0 then
-        util.metals_status("Metals installed!")
+        status.set_status("Metals installed!")
         log.info_and_show("Metals installed! Start/Restart the server, and have fun coding Scala!")
       else
         log.error_and_show("Something went wrong with the Metals install. Please check the logs.")
-        util.metals_status("Install failed!")
+        status.set_status("Install failed!")
       end
     end),
     on_stdout = vim.schedule_wrap(function(err, data)
       if err then
         log.error_and_show(err)
       else
-        util.metals_status(data)
+        status.set_status(data)
       end
     end),
     on_stderr = vim.schedule_wrap(function(err, data)
       if err then
         log.error_and_show(err)
       else
-        util.metals_status(data)
+        status.set_status(data)
         log.info(data)
       end
     end),

--- a/lua/metals/status.lua
+++ b/lua/metals/status.lua
@@ -1,0 +1,55 @@
+local log = require("metals.log")
+
+-- @param status (string) a new status to be displayed
+local function set_status(status)
+  vim.api.nvim_set_var("metals_status", status)
+end
+
+local function prompt_command(status)
+  vim.ui.select({ "yes", "no" }, {
+    prompt = string.format(
+      "%s\nThere is a %s command attatched to this, would you like to execute it?",
+      status.tooltip,
+      status.command
+    ),
+  }, function(choice)
+    if choice == "yes" then
+      local client = vim.lsp.get_client_by_id(status.client_id)
+      local fn = client.commands[status.command]
+      if fn then
+        fn(status.command, { bufnr = status.bufnr, client_id = status.client_id })
+      else
+        log.error_and_show(
+          string.format(
+            "It seems we don't implement %s as a client command. We should, tell Chris to fix this.",
+            status.command
+          )
+        )
+      end
+    end
+  end)
+end
+
+-- Used to handle the full status response from Metals
+-- @param status (table) this is the normal status table as described in the
+--                       metals docs as well as the bufnr and client_id.
+local function handle_status(status)
+  if status.hide then
+    set_status("")
+  else
+    if status.text then
+      set_status(status.text)
+    end
+
+    if status.command and status.tooltip then
+      prompt_command(status)
+    elseif status.tooltip then
+      log.warn_and_show(status.tooltip)
+    end
+  end
+end
+
+return {
+  handle_status = handle_status,
+  set_status = set_status,
+}

--- a/lua/metals/util.lua
+++ b/lua/metals/util.lua
@@ -1,5 +1,3 @@
-local api = vim.api
-
 local Path = require("plenary.path")
 
 local M = {}
@@ -28,14 +26,6 @@ M.check_exists_and_merge = function(defaultTable, userTable)
     return defaultTable
   else
     return vim.tbl_extend("force", defaultTable, userTable)
-  end
-end
-
-M.metals_status = function(text)
-  if text then
-    api.nvim_set_var("metals_status", text)
-  else
-    api.nvim_set_var("metals_status", "")
   end
 end
 


### PR DESCRIPTION
I'm going to probably play around with this for a while to see if I like
it before merging, but the idea here is that in situations where
something goes wrong it might be hard to tell because you only get the
small status message. Now you'll actually get a select that will show
you the tooltip and the command if there is one, or it will just warn
you of what the tooltip says.

Fixes #102