### PR TITLE
feat: introduce a latest.snapshot value for serverVersion.

### DIFF
--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -125,6 +125,11 @@ snapshot version in your settings table: >
   }
 <
 
+You can also just default to the latest snapshot by setting this to
+`latest.snapshot`. NOTE: that while this will pull in the latest snapshot it
+happens during the actual install, not automatically all the time. So you
+still need to trigger a |:MetalsUpdate| regularly to get the newest snapshots.
+
 If no version is set, it defaults to the latest stable release. If a new
 release comes out or you change your server version, you can issue a
 |MetalsUpdate| command to re-install it.
@@ -384,7 +389,8 @@ Default: 'latest.stable' ~
 Targeted server version that you'd like to install. Note that if this is
 changed you need to do a |:MetalsInstall| or |:MetalsUpdate| again to ensure
 that it is installed. If you need to check what version you're currently
-using, you can use the |MetalsInfo| command.
+using, you can use the |MetalsInfo| command. NOTE: that `latest.snapshot` is
+also available as a value to install whatever the latest snapshot is.
 
 showImplicitArguments                                    *showImplicitArguments*
 

--- a/lua/metals/install.lua
+++ b/lua/metals/install.lua
@@ -6,60 +6,10 @@ local util = require("metals.util")
 
 local Job = require("plenary.job")
 
--- There is absolutely no difference with installing or updating, so if a user
--- executes `:MetalsInstall` it will just install the latest or install what they
--- have set no matter what. If there is an existing Metals there, it is then
--- overwritten by the bootstrap command.
--- NOTE: that if a user has useGlobalExecutable set, this will just throw an
--- error at them since they can't use this in that case.
--- @param sync (boolean) really only used for testing. If you are running test-setup
--- then set this to true, else just let it be.
-local function install_or_update(sync)
-  local config = conf.get_config_cache()
-  if config.settings.metals.useGlobalExecutable then
-    log.error_and_show(messages.use_global_set_so_cant_update)
-    return true
-  end
-
-  local coursier_exe = conf.check_for_coursier()
-  if not coursier_exe then
-    log.error_and_show(messages.coursier_installed)
-    return true
-  end
-
-  local latestStable = "latest.release"
-  local server_version = config.settings.metals.serverVersion or latestStable
-  local binary_version = "2.12"
-  -- TODO When we release 0.11.3 we need to change this to:
-  -- if server_version == latestStable or server_version > "0.11.2" then
-  if server_version ~= latestStable and server_version > "0.11.2" then
-    binary_version = "2.13"
-  end
-
-  local server_org = config.settings.metals.serverOrg or "org.scalameta"
-
-  if not util.nvim_metals_cache_dir:exists() then
-    util.nvim_metals_cache_dir:mkdir()
-  end
-
-  status.set_status("Installing Metals...")
-
-  local args = {
-    "bootstrap",
-    "--java-opt",
-    "-Xss4m",
-    "--java-opt",
-    "-Xms100m",
-    string.format("%s:metals_%s:%s", server_org, binary_version, server_version),
-    "-r",
-    "bintray:scalacenter/releases",
-    "-r",
-    "sonatype:snapshots",
-    "-o",
-    conf.metals_install_name(),
-    "-f",
-  }
-
+-- The main job that actually installs Metals
+-- @param coursier_exe (string) the coursier executable to be used
+-- @param args (table) args to pass into the install job
+local function install_job(coursier_exe, args)
   local job = Job:new({
     command = coursier_exe,
     args = args,
@@ -88,10 +38,103 @@ local function install_or_update(sync)
       end
     end),
   })
-  if sync then
-    job:sync(10000)
+  return job
+end
+
+-- Puts together the args that will be passed into the actual install
+-- @param server_org (string) this will default to org.scalameta, but just in case
+-- @param binary_version (string) either 2.12 or 2.13 for now
+-- @param version (string) the version of metals to install
+-- @return a table of args for the install
+local function create_args_for_install(server_org, binary_version, version)
+  print("creating args")
+  return {
+    "bootstrap",
+    "--java-opt",
+    "-Xss4m",
+    "--java-opt",
+    "-Xms100m",
+    string.format("%s:metals_%s:%s", server_org, binary_version, version),
+    "-r",
+    "bintray:scalacenter/releases",
+    "-r",
+    "sonatype:snapshots",
+    "-o",
+    conf.metals_install_name(),
+    "-f",
+  }
+end
+
+-- There is absolutely no difference with installing or updating, so if a user
+-- executes `:MetalsInstall` it will just install the latest or install what they
+-- have set no matter what. If there is an existing Metals there, it is then
+-- overwritten by the bootstrap command.
+-- NOTE: that if a user has useGlobalExecutable set, this will just throw an
+-- error at them since they can't use this in that case.
+local function install_or_update()
+  local config = conf.get_config_cache()
+  if config.settings.metals.useGlobalExecutable then
+    log.error_and_show(messages.use_global_set_so_cant_update)
+    return
+  end
+
+  local coursier_exe = conf.check_for_coursier()
+  if not coursier_exe then
+    log.error_and_show(messages.coursier_installed)
+    return
+  end
+
+  if not util.nvim_metals_cache_dir:exists() then
+    util.nvim_metals_cache_dir:mkdir()
+  end
+
+  local latest_stable = "latest.release"
+  local latest_snapshot = "latest.snapshot"
+  local the_one_true_metals = "org.scalameta"
+  local server_version = config.settings.metals.serverVersion or latest_stable
+
+  local binary_version = "2.12"
+  -- TODO When we release 0.11.3 we need to change this to:
+  -- if server_version == latestStable or server_version > "0.11.2" then
+  if server_version ~= latest_stable and server_version > "0.11.2" then
+    binary_version = "2.13"
+  end
+
+  local server_org = config.settings.metals.serverOrg or the_one_true_metals
+
+  status.set_status("Installing Metals...")
+
+  if server_version == latest_snapshot and server_org == the_one_true_metals then
+    -- This is sort of a workaround to ensure that latest.snapshot works. If
+    -- the user sets this we actually reach out to the metals site at
+    -- latests.json to get the latest snapshot version and then do the actual
+    -- install job. Coursier won't handle latest.snapshot for us or return all the snapshots
+    -- if asks, so that's why we resort to this madness.
+    -- https://github.com/scalameta/nvim-metals/issues/122
+    Job
+      :new({
+        command = "curl",
+        args = {
+          "-s",
+          "https://scalameta.org/metals/latests.json",
+        },
+        on_exit = vim.schedule_wrap(function(self, job_status)
+          if job_status == 0 then
+            local versions = vim.fn.json_decode(table.concat(self._stdout_results, ""))
+            local version = versions.snapshot or latest_stable
+            install_job(coursier_exe, create_args_for_install(server_org, binary_version, version)):sync(10000)
+          else
+            log.error_and_show("Something went wrong getting the latest snapshot so defaulting to latest stable.")
+            server_version = latest_stable
+          end
+        end),
+      })
+      :sync()
+  elseif server_version == latest_snapshot then
+    log.error_and_show("You must be using mainline metals to use the latest.snapshot feature")
+    return
   else
-    job:start()
+    install_job(coursier_exe, create_args_for_install(server_org, binary_version, server_version)):sync(10000)
   end
 end
 

--- a/tests/setup/install_spec.lua
+++ b/tests/setup/install_spec.lua
@@ -11,14 +11,14 @@ describe("install", function()
     path:rm()
   end)
 
-  it("should be able to install", function()
+  it("should be able to install latest.stable", function()
     -- Just initialized an empty config since when you try to install it will try
     -- to access your config.metals.settings table
     local current_buf = vim.api.nvim_get_current_buf()
     local _ = config.validate_config({}, current_buf)
 
     eq(path:exists(), false)
-    install.install_or_update(true)
+    install.install_or_update()
     eq(path:exists(), true)
   end)
 
@@ -28,7 +28,7 @@ describe("install", function()
     config.validate_config(bare_config, vim.api.nvim_get_current_buf())
 
     eq(path:exists(), false)
-    install.install_or_update(true)
+    install.install_or_update()
     eq(path:exists(), true)
   end)
 
@@ -38,7 +38,29 @@ describe("install", function()
     config.validate_config(bare_config, vim.api.nvim_get_current_buf())
 
     eq(path:exists(), false)
-    install.install_or_update(true)
+    install.install_or_update()
+    eq(path:exists(), true)
+  end)
+
+  it("should block you from using latest.snapshot with a imposter metals", function()
+    local bare_config = require("metals.setup").bare_config()
+    bare_config.settings = { serverVersion = "latest.snapshot", serverOrg = "some-other-org" }
+    config.validate_config(bare_config, vim.api.nvim_get_current_buf())
+
+    eq(path:exists(), false)
+    install.install_or_update()
+    eq(path:exists(), false)
+  end)
+
+  it("should be able to install with latest.snapshot", function()
+    local bare_config = require("metals.setup").bare_config()
+    bare_config.settings = { serverVersion = "latest.snapshot" }
+    config.validate_config(bare_config, vim.api.nvim_get_current_buf())
+
+    eq(path:exists(), false)
+    -- This takes a bit longer here so we just pause for a couple seconds to
+    -- ensure both jobs runs.
+    vim.wait(2000, install.install_or_update())
     eq(path:exists(), true)
   end)
 end)


### PR DESCRIPTION
Now that this value can be obtained by just looking at the
https://scalameta.org/metals/latests.json file, it makes doing this much
more robust.

fixes #122