### PR TITLE
refactor: add a status message when fetching snapshot

### DIFF
--- a/lua/metals/install.lua
+++ b/lua/metals/install.lua
@@ -112,6 +112,8 @@ local function install_or_update(sync)
   status.set_status("Installing Metals...")
 
   if server_version == latest_snapshot and server_org == the_one_true_metals then
+    status.set_status("Fetching latest snapshot version...")
+
     -- This is sort of a workaround to ensure that latest.snapshot works. If
     -- the user sets this we actually reach out to the metals site at
     -- latests.json to get the latest snapshot version and then do the actual


### PR DESCRIPTION
This shouldn't take long at all, but I noticed at times if you are
fetching the latest snapshot version there might be a slight pause, so
this just adds a status message to notify the user what is going on.
