### PR TITLE
feat: account for version 3 of doctor

### DIFF
--- a/lua/metals/doctor.lua
+++ b/lua/metals/doctor.lua
@@ -33,8 +33,31 @@ end
 --- Create the Doctor.
 -- @param args table of the args give by `metals/executeClientCommand`
 Doctor.create = function(args)
-  local header_text = lsp.util.convert_input_to_markdown_lines({ args.headerText })
-  local output = header_text
+  local output = {}
+
+  table.insert(output, "## Metals Info")
+
+  if args.version >= 3 then
+    local header = args.header
+    local fields = {
+      "serverInfo",
+      "buildTool",
+      "buildServer",
+      "importBuildStatus",
+      "jdkInfo",
+    }
+
+    for _, field in pairs(fields) do
+      if header[field] then
+        table.insert(output, "  - " .. header[field])
+      end
+    end
+    table.insert(output, "")
+    table.insert(output, header.buildTargetDescription)
+  else
+    output = lsp.util.convert_input_to_markdown_lines({ args.headerText })
+  end
+
   table.insert(output, "")
 
   if args.messages then


### PR DESCRIPTION
Version 3 of the doctor format adds in some nice structured goodies in
the header instead of a big string. For example now we also get the jdk
version, the metals version, the bloop version, etc all nicely displayed
for the user. We also kept in logic to ensure that users on old metals
can still use the doctor without stuff blowing up
