### PR TITLE
feat!: utilize new autocmd api

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ integrations with other projects such as
 
 ## Prerequisites
 
-- Before you get started you need to ensure that you are using nvim v.0.6.0 or
+- Before you get started you need to ensure that you are using nvim v.0.7.0 or
     newer.
 - Ensure [Coursier](https://get-coursier.io/docs/cli-installation) is installed
     on your machine. `nvim-metals` uses Coursier to download and update Metals.

--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -31,7 +31,7 @@ the correct `init_options`.
 ================================================================================
 PREREQUISITES                                             *metals-prerequisites*
 
-- Ensure you're using at least Neovim v0.6.0. While `nvim-metals` will aim to
+- Ensure you're using at least Neovim v0.7.0. While `nvim-metals` will aim to
   always work with the latest stable version of Neovim, there is no guarantee
   of compatibility with older versions.
 - WARNING: use this plugin for Metals and also `neovim/nvim-lspconfig` for
@@ -59,24 +59,24 @@ PREREQUISITES                                             *metals-prerequisites*
 - Check out the features list in
   https://github.com/scalameta/nvim-metals/discussions/279. New features will
   always be added there.
+- If you're unfamiliar with configuring Neovim with Lua or not sure how to
+  call Lua from Vimscript, check out the awesome guide at
+  https://github.com/nanotee/nvim-lua-guide. The help docs here always assume
+  Lua.
 
 ================================================================================
 GETTING STARTED                                         *metals-getting-started*
 
 Once installed, the most basic setup is to have the following: >
 
-  augroup lsp
-    au!
-    au FileType java,scala,sbt lua require("metals").initialize_or_attach({})
-  augroup end
-<
-
-Or as a |vim.cmd| if using a pure Lua setup. >
-
-  cmd [[augroup lsp]]
-  cmd [[au!]]
-  cmd [[au FileType java,scala,sbt lua require("metals").initialize_or_attach({})]]
-  cmd [[augroup end]]
+  local nvim_metals_group = api.nvim_create_augroup("nvim-metals", { clear = true })
+  api.nvim_create_autocmd("FileType", {
+    pattern = { "scala", "sbt", "java" },
+    callback = function()
+      require("metals").initialize_or_attach({})
+    end,
+    group = nvim_metals_group,
+  })
 <
 
 This will give you the defaults that Metals provides. The empty `{}` that

--- a/lua/metals/config.lua
+++ b/lua/metals/config.lua
@@ -146,10 +146,14 @@ local valid_nvim_metals_settings = {
 --- auto commands necessary for `metals/didFocusTextDocument`.
 --- https://scalameta.org/metals/docs/integrations/new-editor.html#metalsdidfocustextdocument
 local function auto_commands()
-  api.nvim_command([[augroup NvimMetals]])
-  api.nvim_command([[autocmd!]])
-  api.nvim_command([[autocmd BufEnter * lua require("metals").did_focus()]])
-  api.nvim_command([[augroup end]])
+  local nvim_metals_group = api.nvim_create_augroup("nvim-metals", { clear = true })
+  api.nvim_create_autocmd("BufEnter", {
+    pattern = { "*" },
+    callback = function()
+      require("metals").did_focus()
+    end,
+    group = nvim_metals_group,
+  })
 end
 
 local commands = {}

--- a/lua/metals/doctor.lua
+++ b/lua/metals/doctor.lua
@@ -134,10 +134,16 @@ Doctor.create = function(args)
   api.nvim_buf_set_option(float.bufnr, "filetype", "markdown")
   api.nvim_buf_set_lines(float.bufnr, 0, -1, false, output)
 
-  vim.cmd("autocmd WinLeave <buffer> lua require('metals.doctor').visibility_did_change(false)")
+  local nvim_metals_group = api.nvim_create_augroup("nvim-metals", { clear = true })
 
-  -- we have the win_id and then with that win_id we could set an autocmd that
-  -- on close it calls some function
+  api.nvim_create_autocmd("WinLeave", {
+    buffer = float.bufnr,
+    callback = function()
+      require("metals.doctor").visibility_did_change(false)
+    end,
+    group = nvim_metals_group,
+  })
+
   doctor_win_id = float.win_id
 end
 


### PR DESCRIPTION
This is a breaking change. If you see error messages related to autocmds
after updating this you'll want to ensure that you're on the newly
released 0.7.0 of Neovim.
  - https://github.com/neovim/neovim/releases/tag/v0.7.0

The diff in this commit will give you a good idea of how to migrate the
old style of autocmds to the new style.

Closes #347
