### PR TITLE
fix: make autogroup names unique

### DIFF
--- a/lua/metals/config.lua
+++ b/lua/metals/config.lua
@@ -146,13 +146,12 @@ local valid_nvim_metals_settings = {
 --- auto commands necessary for `metals/didFocusTextDocument`.
 --- https://scalameta.org/metals/docs/integrations/new-editor.html#metalsdidfocustextdocument
 local function auto_commands()
-  local nvim_metals_group = api.nvim_create_augroup("nvim-metals", { clear = true })
   api.nvim_create_autocmd("BufEnter", {
     pattern = { "*" },
     callback = function()
       require("metals").did_focus()
     end,
-    group = nvim_metals_group,
+    group = api.nvim_create_augroup("nvim-metals-focus", { clear = true }),
   })
 end
 

--- a/lua/metals/doctor.lua
+++ b/lua/metals/doctor.lua
@@ -134,14 +134,12 @@ Doctor.create = function(args)
   api.nvim_buf_set_option(float.bufnr, "filetype", "markdown")
   api.nvim_buf_set_lines(float.bufnr, 0, -1, false, output)
 
-  local nvim_metals_group = api.nvim_create_augroup("nvim-metals", { clear = true })
-
   api.nvim_create_autocmd("WinLeave", {
     buffer = float.bufnr,
     callback = function()
       require("metals.doctor").visibility_did_change(false)
     end,
-    group = nvim_metals_group,
+    group = api.nvim_create_augroup("nvim-metals-doctor", { clear = true }),
   })
 
   doctor_win_id = float.win_id


### PR DESCRIPTION
This was screwing up the initialize or attach locally if you had that
autogroup also called nvim-metals since it would clear it due to the
ones internally having the same group name.
