### PR TITLE
refactor: default to 2.13 for latest.snapshot and latest.stable

### DIFF
--- a/lua/metals/install.lua
+++ b/lua/metals/install.lua
@@ -101,9 +101,7 @@ local function install_or_update(sync)
   local server_version = config.settings.metals.serverVersion or latest_stable
 
   local binary_version = "2.12"
-  -- TODO When we release 0.11.3 we need to change this to:
-  -- if server_version == latestStable or server_version > "0.11.2" then
-  if server_version ~= latest_stable and server_version > "0.11.2" then
+  if server_version == latest_stable or server_version == latest_snapshot or server_version > "0.11.2" then
     binary_version = "2.13"
   end
 

--- a/tests/setup/install_spec.lua
+++ b/tests/setup/install_spec.lua
@@ -22,9 +22,9 @@ describe("install", function()
     eq(path:exists(), true)
   end)
 
-  it("should be able to install with an old 2.12 snapshot", function()
+  it("should be able to install with an old 2.12", function()
     local bare_config = require("metals.setup").bare_config()
-    bare_config.settings = { serverVersion = "0.10.9+131-30f6a57b-SNAPSHOT" }
+    bare_config.settings = { serverVersion = "0.11.0" }
     config.validate_config(bare_config, vim.api.nvim_get_current_buf())
 
     eq(path:exists(), false)


### PR DESCRIPTION
Now that the new Metals version is out latest.snapshot and latest.stable
should both default to the 2.13 artifacts since that's what metals is
publishing.