### PR TITLE
fix: Ensure find in dependency jars is always using a valid buf

### DIFF
--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -252,7 +252,7 @@ end
 
 M.find_in_dependency_jars = function()
   local function send_request(mask, query)
-    lsp.buf_request(0, "metals/findTextInDependencyJars", {
+    lsp.buf_request(util.find_metals_buffer(), "metals/findTextInDependencyJars", {
       options = { include = mask },
       query = { pattern = query },
     })


### PR DESCRIPTION
Since it's common to probably use this when you're inside of a .conf
file, Metals won't actually be attached to the current buffer, which
will cause this to just do nothing. So instead of using 0, we'll always
search and use a valid metals buffer.

fix #382