### PR TITLE
test: start adding in handler tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ test-setup:
 test:
 	nvim --headless --noplugin -u tests/minimal.vim -c "PlenaryBustedDirectory tests/tests/ { minimal_init = 'tests/minimal.vim', sequential = true }"
 
+test-handlers:
+	nvim --headless --noplugin -u tests/minimal.vim -c "PlenaryBustedDirectory tests/tests/handlers/ { minimal_init = 'tests/minimal.vim', sequential = true }"
+
 test-all:
 	nvim --headless --noplugin -u tests/minimal.vim -c "PlenaryBustedDirectory tests/ { minimal_init = 'tests/minimal.vim' }"
 

--- a/neovim.toml
+++ b/neovim.toml
@@ -8,6 +8,9 @@
 [[assert.are.same.args]]
   type = "any"
 
+[[assert.stub.args]]
+  type = "any"
+
 [[before_each.args]]
   type = "function"
 

--- a/tests/tests/handlers/quickpick_spec.lua
+++ b/tests/tests/handlers/quickpick_spec.lua
@@ -1,0 +1,30 @@
+local handlers = require("metals.handlers")
+local stub = require("luassert.stub")
+
+describe("metals quickpick", function()
+  it("correctly puts together lables for the user to choose", function()
+    stub(vim.fn, "inputlist")
+
+    local items = {
+      items = {
+        {
+          id = "scala-class",
+          label = "Class",
+        },
+        {
+          id = "scala-trait",
+          label = "Trait",
+        },
+      },
+      placeHolder = "Select the kind of file to create",
+    }
+
+    local labels = {
+      "1 - Class",
+      "2 - Trait",
+    }
+
+    handlers["metals/quickPick"](nil, items)
+    assert.stub(vim.fn.inputlist).was_called_with(labels)
+  end)
+end)


### PR DESCRIPTION
The goal will be to test all of the custom handlers for Metals. While we
probably won't be able to test the full cycle of communication with
these between server and client we can at least test the Neovim side of
things and mock what we need to. This will at least ensure that when a
specific handler is called we aren't using an old API and we can catch
changes in the loads that Metals is sending us.

This first test covers `metals/quickpick`