### PR TITLE
refactor(decorations): migrate decorations to use extmarks

### DIFF
--- a/lua/metals/decoration.lua
+++ b/lua/metals/decoration.lua
@@ -1,38 +1,73 @@
 local api = vim.api
+local log = require("metals.log")
 local lsp = require("vim.lsp")
-
-local M = {}
 
 local hover_messages = {}
 local hover_color = "Conceal"
 
-M.set_decoration = function(bufnr, decoration_ns, decoration)
+local M = {}
+
+M.decoration_namespace = function()
+  return api.nvim_create_namespace("metals_decoration")
+end
+
+M.set_decoration = function(bufnr, decoration)
   local line = decoration.range["end"].line
   local text = decoration.renderOptions.after.contentText
   local virt_texts = {}
   table.insert(virt_texts, { text, hover_color })
-  api.nvim_buf_set_virtual_text(bufnr, decoration_ns, line, virt_texts, {})
-end
 
-M.store_hover_message = function(decoration)
-  local hover_line = decoration.range["end"].line + 1
-  local hover_message = lsp.util.convert_input_to_markdown_lines(decoration.hoverMessage)
+  local ext_id = api.nvim_buf_set_extmark(bufnr, M.decoration_namespace(), line, -1, { virt_text = virt_texts })
+
+  local hover_message = lsp.util.convert_input_to_markdown_lines(decoration.hoverMessage, {})
   hover_message = lsp.util.trim_empty_lines(hover_message)
-  hover_messages[hover_line] = hover_message
+
+  hover_messages[ext_id] = hover_message
 end
 
 M.hover_worksheet = function()
-  local row, _ = unpack(api.nvim_win_get_cursor(0))
-  local hover_message = hover_messages[row]
+  local buf = api.nvim_get_current_buf()
+  local line, _ = unpack(api.nvim_win_get_cursor(0))
 
-  if hover_message == nil then
+  local exists, ext_ids = pcall(
+    api.nvim_buf_get_extmarks,
+    buf,
+    M.decoration_namespace(),
+    { line - 1, 0 },
+    { line - 1, -1 },
+    { details = true }
+  )
+
+  if not exists then
     return
-  end
+    -- In reality extmarks can have x amount extmarks in any given position,
+    -- but with worksheets it's only logical to have an extmark one per line
+    -- (after evaluation). So we double check this. If this does happen, then
+    -- I've done something wrong with my logic here.
+  elseif #ext_ids > 1 then
+    log.error_and_show(
+      "Recieved two extmarks on a single line. This should never happen with worksheets. Please create a nvim-metals issue."
+    )
+    return
+  elseif #ext_ids == 1 then
+    -- We only want the extmark_id which is in pos 1
+    local id = ext_ids[1][1]
 
-  lsp.util.open_floating_preview(hover_message, "markdown", { pad_left = 1, pad_right = 1 })
+    local hover_message = hover_messages[id]
+
+    -- This also shuoldn't happen but to avoid an empty window we do a sanity check
+    if hover_message == nil then
+      return
+    end
+
+    lsp.util.open_floating_preview(hover_message, "markdown", { pad_left = 1, pad_right = 1 })
+  end
 end
 
-M.clear_hover_messages = function()
+-- Clears both the hover messages in the hover_messages table but also the
+-- extmarks in the decoration namespace.
+M.clear = function(bufnr)
+  api.nvim_buf_clear_namespace(bufnr, M.decoration_namespace(), 0, -1)
   hover_messages = {}
 end
 

--- a/lua/metals/handlers.lua
+++ b/lua/metals/handlers.lua
@@ -9,8 +9,6 @@ local status = require("metals.status")
 
 local M = {}
 
-local decoration_namespace = api.nvim_create_namespace("metals_decoration")
-
 -- Implementation of the `metals/quickPick` Metals LSP extension.
 -- https://scalameta.org/metals/docs/integrations/new-editor/#metalsquickpick
 M["metals/quickPick"] = function(_, result)
@@ -88,6 +86,7 @@ M["metals/publishDecorations"] = function(err, result)
 
   local uri = result.uri
   local bufnr = vim.uri_to_bufnr(uri)
+
   if not bufnr then
     log.warn_and_show(string.format("Couldn't find buffer for %s while publishing decorations.", uri))
     return
@@ -99,12 +98,10 @@ M["metals/publishDecorations"] = function(err, result)
     return
   end
 
-  api.nvim_buf_clear_namespace(bufnr, decoration_namespace, 0, -1)
-  decoration.clear_hover_messages()
+  decoration.clear(bufnr)
 
   for _, deco in ipairs(result.options) do
-    decoration.set_decoration(bufnr, decoration_namespace, deco)
-    decoration.store_hover_message(deco)
+    decoration.set_decoration(bufnr, deco)
   end
 end
 

--- a/tests/tests/decoration_spec.lua
+++ b/tests/tests/decoration_spec.lua
@@ -1,0 +1,58 @@
+describe("decorations", function()
+  local decoration = require("metals.decoration")
+  local bufnr = vim.api.nvim_get_current_buf()
+  vim.api.nvim_buf_set_lines(bufnr, 0, 0, false, { "val x = 3" })
+
+  local base_decoration = {
+    range = {
+      start = {
+        line = 0,
+        character = 0,
+      },
+      ["end"] = {
+        line = 0,
+        character = 9,
+      },
+    },
+    hoverMessage = {
+      kind = "markdown",
+      value = "```scala\nx: Int 1\n```",
+    },
+    renderOptions = {
+      after = {
+        contentText = " // : Int 1",
+        fontStyle = "italic",
+        color = "green",
+      },
+    },
+  }
+
+  it("should be able to correctly set decorations", function()
+    local bufs_before = vim.api.nvim_list_bufs()
+    decoration.set_decoration(bufnr, base_decoration)
+    vim.api.nvim_win_set_cursor(0, { 1, 1 })
+    decoration.hover_worksheet()
+    local bufs_after = vim.api.nvim_list_bufs()
+    -- We should have one more floating buf now with the contents of the virtual text
+    assert.are.same(#bufs_before + 1, #bufs_after)
+
+    local hover_contents = vim.api.nvim_buf_get_lines(bufs_after[#bufs_after], 0, 1, true)
+
+    assert.are.same(1, #hover_contents)
+    assert.are.same("x: Int 1", hover_contents[1])
+  end)
+
+  it("should be able to clear and replace existing decorations", function()
+    decoration.clear(bufnr)
+    base_decoration.hoverMessage.value = "```scala\nx: Int 2\n```"
+    base_decoration.renderOptions.after.contentText = " // : Int 2"
+    decoration.set_decoration(bufnr, base_decoration)
+    decoration.hover_worksheet()
+    local bufs_after = vim.api.nvim_list_bufs()
+
+    local hover_contents = vim.api.nvim_buf_get_lines(bufs_after[#bufs_after], 0, 1, true)
+
+    assert.are.same(1, #hover_contents)
+    assert.are.same("x: Int 2", hover_contents[1])
+  end)
+end)


### PR DESCRIPTION
Since `nvim_buf_set_virtual_text` is deprecated I figured it was time to
do a migration to the new way of dealing with virtual text using
extmarks. In some ways it's more verbose, but there are more
possiblities. This also slightly changes the behavior now with the
virtual text shifting with the lines until they are replaced. I'm not
sure I love that, but I'm not 100% sure there is an easy way to avoid
that unless we do a clear when entering insert mode. We'll see if people
complain.

This also adds in tests to cover the decorations package.