### PR TITLE
fix: ensure mkdir called with parents = true

### DIFF
--- a/lua/metals/log.lua
+++ b/lua/metals/log.lua
@@ -51,7 +51,7 @@ M.nvim_metals_log = Path:new(util.nvim_metals_cache_dir, "nvim-metals.log").file
 
 local generate_log_functions = function()
   if not util.nvim_metals_cache_dir:exists() then
-    util.nvim_metals_cache_dir:mkdir()
+    util.nvim_metals_cache_dir:mkdir({ parents = true })
   end
   local log_at_level = function(level, show_user, ...)
     local nameupper = level:upper()


### PR DESCRIPTION
I have no idea how this was working before and why it breaks with
nightly, but this should fix the issues we've been seeing in CI