### PR TITLE
feat: allows toggle logs to be horizontal or vertical

### DIFF
--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -910,9 +910,12 @@ super_method_hierarchy()  Use to execute a |metals.super-method-hierarchy|
 switch_bsp()              Use to execute a |metals.bsp-switch| command.
 
                                                                  *toggle_logs()*
-toggle_logs()             Use to trigger a |tail -f .metals/log| on your
+toggle_logs({direction}) Use to trigger a |tail -f .metals/log| on your
                           current workspace that will open in the embedded
                           Neovim terminal.
+
+                          Parameters: {direction} (string) This can either be
+                          vsp to split vertically or sp for a horizontal split.
 
                                                               *toggle_setting()*
 toggle_setting({setting})

--- a/lua/metals/commands.lua
+++ b/lua/metals/commands.lua
@@ -191,6 +191,7 @@ local commands_table = {
     id = "toggle_logs",
     label = "Toggle Logs",
     hint = "Toggle Metals logs.",
+    expected_args = 1,
   },
   {
     id = "update",

--- a/lua/metals/setup.lua
+++ b/lua/metals/setup.lua
@@ -42,9 +42,9 @@ end
 local function add_commands()
   for _, cmd in pairs(commands_table) do
     local vim_cmd = util.camel_to_pascal(cmd.id)
-    api.nvim_create_user_command("Metals" .. vim_cmd, function()
-      require("metals")[cmd.id]()
-    end, {})
+    api.nvim_create_user_command("Metals" .. vim_cmd, function(args)
+      require("metals")[cmd.id](args.args)
+    end, { nargs = cmd.expected_args or 0 })
   end
 end
 


### PR DESCRIPTION
This makes a couple small changes that allows the toggle logs command to
be able to take a param to either open vertically or horizontally. It
now takes a direction of either `vsp` or `sp` with a default of `vsp`.
This also makes a small change that when we create the user commands we
pass in whether or not an arg is expected, and you can set the amount of
args in the commands table.

Closes #250