### PR TITLE
fix empty strings as args passed always as arguments for neovim 0.7+

### DIFF
--- a/lua/metals/config.lua
+++ b/lua/metals/config.lua
@@ -164,7 +164,7 @@ local function toggle_logs(direction)
   local bufs = api.nvim_list_bufs()
   local split_direction = "vsp"
 
-  if direction and direction ~= "" then
+  if direction then
     if direction ~= "vsp" and direction ~= "sp" then
       log.error_and_show("direction must be able vsp or sp")
       return

--- a/lua/metals/setup.lua
+++ b/lua/metals/setup.lua
@@ -39,11 +39,19 @@ local function bare_config()
   return { handlers = {}, init_options = { compilerOptions = {} }, settings = {}, tvp = {} }
 end
 
+local function map_empty_args(args)
+  if args == "" then
+    return nil
+  else
+    return args
+  end
+end
+
 local function add_commands()
   for _, cmd in pairs(commands_table) do
     local vim_cmd = util.camel_to_pascal(cmd.id)
     api.nvim_create_user_command("Metals" .. vim_cmd, function(args)
-      require("metals")[cmd.id](args.args)
+      require("metals")[cmd.id](map_empty_args(args.args))
     end, { nargs = cmd.nargs or 0 })
   end
 end


### PR DESCRIPTION
Since neovim 0.7 this repository changed command creation into new api `api.nvim_create_user_command`.
It thou changed it's behavior and made `MetalsNew(Scala/Java)File` unusable as it now passed empty strings instead of nil when no arguments were given. It lead to funny behaviors for optional arguments which were present in 
`local new_file = function(language, directory_uri_opt, name_opt, file_type_opt)` implementation so directory_uri_opt on metals side was `Some("")` instead of None. It threw runtime error which now is fixed and all commands arguments are now nil when they equal `""`

This change in neovim API looks like is intended according to tests:
https://github.com/gpanders/neovim/blob/0d188f718b64aacd69f61eed54f6c47a1cb08414/test/functional/api/command_spec.lua#L192