### PR TITLE
feat: allow user to override config.cmd

### DIFF
--- a/lua/metals/config.lua
+++ b/lua/metals/config.lua
@@ -358,7 +358,14 @@ local function validate_config(config, bufnr)
     all_opts[i] = "-J" .. opt
   end
 
-  config.cmd = util.merge_lists({ metals_bin() }, all_opts)
+  -- If the user overrides config.cmd then they are sort of on there on to ensure that
+  -- what they are passing in can correctly start Metals. Also keep in mind that by doing
+  -- this none of the metals.serverProperties will be applied and none of the java_opts
+  -- from the workspce will be either. We basically have no idea what someone is overriding
+  -- this with, so if they do, they are 100% on their own here.
+  if not config.cmd then
+    config.cmd = util.merge_lists({ metals_bin() }, all_opts)
+  end
 
   -- This shouldn't really be needed as it doesn't do anything in core,
   -- however, I'm adding this in now for

--- a/tests/tests/config_spec.lua
+++ b/tests/tests/config_spec.lua
@@ -71,4 +71,13 @@ describe("config", function()
     local valid_config = config.validate_config(bare_config, current_buf)
     eq(valid_config.tvp.panel_width, 1000)
   end)
+
+  it("should be able to handle a custom cmd without adding anything to it", function()
+    local bare_config = require("metals.setup").bare_config()
+    local cmd = { "cs", "launch", "metals" }
+    bare_config.cmd = cmd
+
+    local valid_config = config.validate_config(bare_config, current_buf)
+    eq(valid_config.cmd, cmd)
+  end)
 end)


### PR DESCRIPTION
NOTE: That when doing this, you're 100% on your own with how Metals gets
started. If what you pass in doesn't work, then nothing will work. Also
keep in mind that no java_opts or `config.server_opts` that you pass in
will be applied. You'll need to apply them yourself in the `cmd` table.

This isn't added to the docs because if you're sane you shouldn't do
this. This is for Anton.
