### PR TITLE
feat: add in metalsBinaryPath

### DIFF
--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -186,6 +186,7 @@ _ones that are sent and used by the server_
 _ones that are used internally by `nvim-metals`_
   * |disabledMode|
   * |decorationColor|
+  * |metalsBinaryPath|
   * |serverOrg|
   * |serverVersion|
   * |useGlobalExecutable|
@@ -343,6 +344,15 @@ Optional absolute path to a mill executable to use for running mill
 mill.contrib.Bloop/install. By default, Metals uses mill wrapper script with
 0.5.0 mill version. Update this setting if your mill script requires more
 customizations like using environment variables.
+
+metalsBinaryPath                                              *metalsBinaryPath*
+
+Type: string ~
+Default: '' ~
+
+Another setting for you crazy Nix kids. If you'd like to pass in a specific
+Metals instance that isn't a global executable, you can do so by setting this
+to the absolute path of Metals.
 
 remoteLanguageServer                                      *remoteLanguageServer*
 

--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -126,6 +126,8 @@ M.info = function()
   local config = conf.get_config_cache()
   if not util.has_bins(conf.metals_bin()) and config.settings.metals.useGlobalExecutable then
     log.error_and_show(messages.use_global_set_but_cant_find)
+  elseif not util.has_bins(conf.metals_bin()) and config.settings.metals.metalsBinaryPath then
+    log.error_and_show(messages.binary_path_set_but_cant_find)
   elseif not util.has_bins(conf.metals_bin()) then
     log.warn_and_show(messages.metals_not_installed)
   else

--- a/lua/metals/install.lua
+++ b/lua/metals/install.lua
@@ -72,13 +72,18 @@ end
 -- executes `:MetalsInstall` it will just install the latest or install what they
 -- have set no matter what. If there is an existing Metals there, it is then
 -- overwritten by the bootstrap command.
--- NOTE: that if a user has useGlobalExecutable set, this will just throw an
--- error at them since they can't use this in that case.
+-- NOTE: that if a user has useGlobalExecutable or metalsBinaryPath set,
+-- this will just throw an error at them since they can't use this in that case.
 -- @param sync (boolean) whether the run the job sync or async (mainly used for testing)
 local function install_or_update(sync)
   local config = conf.get_config_cache()
   if config.settings.metals.useGlobalExecutable then
     log.error_and_show(messages.use_global_set_so_cant_update)
+    return
+  end
+
+  if config.settings.metals.metalsBinaryPath then
+    log.error_and_show(messages.binary_path_set_so_cant_update)
     return
   end
 
@@ -117,7 +122,7 @@ local function install_or_update(sync)
     -- https://github.com/scalameta/nvim-metals/issues/122
     local res = Curl.get("https://scalameta.org/metals/latests.json", { accept = "application/json" })
 
-    if res.status == 200 then
+    if res and res.status == 200 then
       server_version = vim.fn.json_decode(res.body).snapshot
     else
       log.error_and_show("Something went wrong getting the latest snapshot so defaulting to latest stable.")

--- a/lua/metals/messages.lua
+++ b/lua/metals/messages.lua
@@ -1,6 +1,14 @@
 -- Used mainly for long messages to no clog up the other files
 local M = {}
 
+M.binary_path_set_but_cant_find = [[
+You have `metalsBinaryPath` set, but it seems to not exist.
+Please make sure it exists and try again..]]
+
+M.binary_path_set_so_cant_update = [[
+You have `metalsBinaryPath` set , so nvim-metals can't install or update your Metals executable.
+If you'd like nvim-metals to handle this for you, remove the `metalsBinaryPath` setting and try again.]]
+
 M.coursier_not_installed = [[
 It looks like you don't have Coursier installed, which you need to install Metals.
 


### PR DESCRIPTION
Another feature that should be useful for Nix users. In the situation where
they don't want nvim-metals to control the install, but also don't want to
use a global executable, this will allow them to instead use `metalsBinaryPath`
which allows you to pass in any path.

Know that you can't use this _with_ `useGlobalExecutable`. If you do, it will take
priority and win.

Addresses #454