### PR TITLE
fix: remove manual didChangeConfiguration call

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ the available features
 
 ## Prerequisites
 
-- Before you get started you need to ensure that you are using nvim v.0.7.0 or
-    newer.
+- Before you get started you need to ensure that you are using nvim v.0.8.0 or
+    newer. If you're still on v0.7.x then you'll want to target the `v0.7.x`
+    tag.
 - Ensure [Coursier](https://get-coursier.io/docs/cli-installation) is
     installed locally.[^coursier]
 - Ensure that you have all the LSP mappings for the core functionality you want

--- a/lua/metals/config.lua
+++ b/lua/metals/config.lua
@@ -378,10 +378,6 @@ local function validate_config(config, bufnr)
   -- lspsaga it will still work as expected for the lsp_finder()
   config.filetypes = { "sbt", "scala" }
 
-  config.on_init = function(client, _)
-    return client.notify("workspace/didChangeConfiguration", { settings = config.settings })
-  end
-
   if not config.on_attach then
     config.on_attach = auto_commands
   else


### PR DESCRIPTION
This is now done in core via https://github.com/neovim/neovim/pull/18847
so we can safely remove this from nvim-metals. I also realized that this
was probably breaking assumptions in the past if anyone tried to
override the `on_init` handler. Now this should work as expected when a
user tries to override.

Closes #465
