### PR TITLE
feat: set virtual text highlight mode to combine

### DIFF
--- a/lua/metals/decoration.lua
+++ b/lua/metals/decoration.lua
@@ -18,7 +18,8 @@ M.set_decoration = function(bufnr, decoration)
   local virt_texts = {}
   table.insert(virt_texts, { text, hover_color })
 
-  local ext_id = api.nvim_buf_set_extmark(bufnr, M.decoration_namespace(), line, -1, { virt_text = virt_texts })
+  local virt_text_opts = { virt_text = virt_texts, hl_mode = "combine" }
+  local ext_id = api.nvim_buf_set_extmark(bufnr, M.decoration_namespace(), line, -1, virt_text_opts)
 
   local hover_message = lsp.util.convert_input_to_markdown_lines(decoration.hoverMessage, {})
   hover_message = lsp.util.trim_empty_lines(hover_message)


### PR DESCRIPTION
  The effect of this change that the cursorline applies to the virtual
  text too in worksheet mode.

Before:
<img width="1532" alt="Screenshot 2022-10-18 at 8 18 06" src="https://user-images.githubusercontent.com/6475233/196351120-9d268d50-c41d-402e-9076-7a1f7c94fbf2.png">

After:
<img width="1532" alt="Screenshot 2022-10-18 at 8 05 38" src="https://user-images.githubusercontent.com/6475233/196351220-205da412-dba6-40e6-a497-af5b087e39c8.png">

I'm not sure if it ok to set this by default, it looks better imho, but I'm open to make this configurable.