### PR TITLE
feat: add test explorer

### DIFF
--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -506,6 +506,8 @@ The following commands are provided by `nvim-metals`:
   * |MetalsRunDoctor|
   * |MetalsRunScalafix|
   * |MetalsScanSources|
+  * |MetalsSelectTestCase|
+  * |MetalsSelectTestSuite|
   * |MetalsShowBuildTargetInfo|
   * |MetalsShowCfr|
   * |MetalsShowJavap|
@@ -643,9 +645,18 @@ MetalsRunScalafix            Runs all of the Scalafix rules that you have
                              to ensure you add them to your settings table
                              under `scalafixRulesDependencies`.
 
-
                                                              *MetalsScanSources*
 MetalsScanSources            Scan all workspaces sources.
+
+                                                          *MetalsSelectTestCase*
+MetalsSelectTestCase         Select the test suite in your workspace to run.
+                             NOTE: this requires additional configuration.
+                             See |metals-nvim-dap|
+
+                                                         *MetalsSelectTestSuite*
+MetalsSelectTestSuite        Select test case from current file to run.
+                             NOTE: this requires additional configuration.
+                             See |metals-nvim-dap|
 
                                                      *MetalsShowBuildTargetInfo*
 MetalsShowBuildTargetInfo    Will return a list of all the build targets in
@@ -1126,7 +1137,7 @@ ensure you have mappings defined and the correct configurations. To get
 started, you'll want ensure that `nvim-dap` is installed and then extend your
 metals configuration with the following `on_attach` function. >
 
-  Metals_config.on_attach = function(client, bufnr)
+  metals_config.on_attach = function(client, bufnr)
     require("metals").setup_dap()
   end
 <
@@ -1196,7 +1207,14 @@ current file and the other for testing the entire target. >
     },
   }
 <
+You may also want to use `Select Test Suite` and `Select Test Case` commands
+to run tests. For them to work correctly you should set `testUserInterface`
+setting. This action will deactivate code lenses for test classes. >
 
+  metals_config.settings = {
+    testUserInterface = "Test Explorer",
+  }
+<
                                                               *metals-telescope*
 
 Metals provides a custom picker from

--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -9,6 +9,7 @@ local install = require("metals.install")
 local log = require("metals.log")
 local messages = require("metals.messages")
 local setup = require("metals.setup")
+local test_explorer = require("metals.test_explorer")
 local util = require("metals.util")
 
 local has_plenary, Float = pcall(require, "plenary.window.float")
@@ -463,6 +464,14 @@ M.toggle_setting = function(setting)
 
     lsp.buf_notify(0, "workspace/didChangeConfiguration", { settings = { metals = settings } })
   end
+end
+
+M.select_test_suite = function()
+  test_explorer.dap_select_test_suite(conf.get_config_cache().root_dir)
+end
+
+M.select_test_case = function()
+  test_explorer.dap_select_test_case(conf.get_config_cache().root_dir)
 end
 
 return M

--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -467,11 +467,11 @@ M.toggle_setting = function(setting)
 end
 
 M.select_test_suite = function()
-  test_explorer.dap_select_test_suite(conf.get_config_cache().root_dir)
+  test_explorer.dap_select_test_suite()
 end
 
 M.select_test_case = function()
-  test_explorer.dap_select_test_case(conf.get_config_cache().root_dir)
+  test_explorer.dap_select_test_case()
 end
 
 return M

--- a/lua/metals/commands.lua
+++ b/lua/metals/commands.lua
@@ -213,6 +213,16 @@ local commands_table = {
     label = "Update Metals",
     hint = "Update to the latest Metals.",
   },
+  {
+    id = "select_test_suite",
+    label = "Select Test Suite",
+    hint = "Select test suite to run.",
+  },
+  {
+    id = "select_test_case",
+    label = "Select Test Case",
+    hint = "Select test case from current file to run.",
+  },
 }
 
 return {

--- a/lua/metals/commands.lua
+++ b/lua/metals/commands.lua
@@ -216,7 +216,7 @@ local commands_table = {
   {
     id = "select_test_suite",
     label = "Select Test Suite",
-    hint = "Select test suite to run.",
+    hint = "Select the test suite in your workspace to run.",
   },
   {
     id = "select_test_case",

--- a/lua/metals/commands.lua
+++ b/lua/metals/commands.lua
@@ -213,6 +213,9 @@ local commands_table = {
     label = "Update Metals",
     hint = "Update to the latest Metals.",
   },
+}
+
+local dap_commands_table = {
   {
     id = "select_test_suite",
     label = "Select Test Suite",
@@ -224,6 +227,11 @@ local commands_table = {
     hint = "Select test case from current file to run.",
   },
 }
+
+local dap_available, _ = pcall(require, "dap")
+if dap_available then
+  vim.list_extend(commands_table, dap_commands_table)
+end
 
 return {
   commands_table = commands_table,

--- a/lua/metals/config.lua
+++ b/lua/metals/config.lua
@@ -93,6 +93,7 @@ end
 local metals_init_options = {
   compilerOptions = {},
   debuggingProvider = debugging_provider,
+  testExplorerProvider = debugging_provider,
   decorationProvider = true,
   didFocusProvider = true,
   disableColorOutput = true,

--- a/lua/metals/config.lua
+++ b/lua/metals/config.lua
@@ -130,6 +130,7 @@ local valid_metals_settings = {
   "showImplicitConversionsAndClasses",
   "showInferredType",
   "superMethodLensesEnabled",
+  "testUserInterface",
 }
 
 -- We keep these seperated from the `valid_metals_settings` just for clarity.

--- a/lua/metals/handlers.lua
+++ b/lua/metals/handlers.lua
@@ -6,6 +6,7 @@ local decoration = require("metals.decoration")
 local doctor = require("metals.doctor")
 local log = require("metals.log")
 local status = require("metals.status")
+local test_explorer = require("metals.test_explorer")
 
 local M = {}
 
@@ -56,6 +57,8 @@ M["metals/executeClientCommand"] = function(_, result)
     vim.diagnostic.setqflist({ severity = "E" })
   elseif result.command == "metals-model-refresh" then
     lsp.codelens.refresh()
+  elseif result.command == "metals-update-test-explorer" then
+    test_explorer.update_state(result.arguments)
   else
     log.warn_and_show(string.format("Looks like nvim-metals doesn't handle %s yet.", result.command))
   end

--- a/lua/metals/messages.lua
+++ b/lua/metals/messages.lua
@@ -45,7 +45,17 @@ update your Metals executable. If you'd like nvim-metals to handle this for
 you, remove the `useGlobalExecutable` setting and try again.]]
 
 M.setup_dap_without_nvim_dap = [[
-You can call require("metals").setup_dap() without `nvim-dap` being installed.
+You can not call require("metals").setup_dap() without `nvim-dap` being installed.
+Please make sure `mfussenegger/nvim-dap` is installed.]]
+
+M.no_test_suites_found = [[
+No test sutes could be found in current file.]]
+
+M.no_test_cases_found = [[
+No test cases found in selected suite. Fallback to run whose suite.]]
+
+M.run_test_without_nvim_dap = [[
+You can not run test without `nvim-dap` being installed.
 Please make sure `mfussenegger/nvim-dap` is installed.]]
 
 return M

--- a/lua/metals/messages.lua
+++ b/lua/metals/messages.lua
@@ -52,7 +52,7 @@ M.no_test_suites_found = [[
 No test sutes could be found in current file.]]
 
 M.no_test_cases_found = [[
-No test cases found in selected suite. Fallback to run whose suite.]]
+No test cases found in selected suite. Fallback to run whole suite.]]
 
 M.run_test_without_nvim_dap = [[
 You can not run test without `nvim-dap` being installed.

--- a/lua/metals/messages.lua
+++ b/lua/metals/messages.lua
@@ -49,7 +49,7 @@ You can not call require("metals").setup_dap() without `nvim-dap` being installe
 Please make sure `mfussenegger/nvim-dap` is installed.]]
 
 M.no_test_suites_found = [[
-No test sutes could be found in current file.]]
+No test suites could be found in current file.]]
 
 M.no_test_cases_found = [[
 No test cases found in selected suite. Fallback to run whole suite.]]

--- a/lua/metals/setup.lua
+++ b/lua/metals/setup.lua
@@ -100,16 +100,13 @@ local function setup_dap(execute_command)
   end
 
   dap.adapters.scala = function(callback, config)
-    local uri = vim.uri_from_bufnr(0)
     local arguments = {}
-
-    if config.name == "from_lens" then
+    if config.name == "from_lens" or config.name == "Run Test" then
       arguments = config.metals
     else
       local metals_dap_settings = config.metals or {}
-
       arguments = {
-        path = uri,
+        path = vim.uri_from_bufnr(0),
         runType = metals_dap_settings.runType or "run",
         args = metals_dap_settings.args,
         jvmOptions = metals_dap_settings.jvmOptions,

--- a/lua/metals/test_explorer.lua
+++ b/lua/metals/test_explorer.lua
@@ -1,0 +1,178 @@
+local log = require("metals.log")
+local messages = require("metals.messages")
+
+local M = {}
+local state = {}
+
+local TestSuite = {
+  fullyQualifiedClassName = "",
+  className = "",
+  symbol = "",
+  canResolveChildren = false,
+  location = {
+    range = {
+      start = { line = 0, character = 0 },
+      ["end"] = { line = 0, character = 0 },
+    },
+    uri = "",
+  },
+  targetName = "",
+  testCases = nil,
+}
+
+function TestSuite:new(suite, targetName)
+  suite = suite or {}
+  suite.targetName = targetName
+  setmetatable(suite, self)
+  self.__index = self
+  return suite
+end
+
+function TestSuite:add_test_cases(testCases)
+  self.testCases = testCases
+end
+
+local function handle_remove_suite(targetName, event)
+  state[targetName][event.fullyQualifiedClassName] = nil
+end
+
+local function handle_add_suite(targetName, event)
+  state[targetName][event.fullyQualifiedClassName] = TestSuite:new(event, targetName)
+end
+
+local function handle_update_suite_location(targetName, event)
+  state[targetName][event.fullyQualifiedClassName].location = event.location
+end
+
+local function handle_add_test_cases(targetName, event)
+  state[targetName][event.fullyQualifiedClassName]:add_test_cases(event.testCases)
+end
+
+local function handle(targetName, event)
+  if event.kind == "removeSuite" then
+    handle_remove_suite(targetName, event)
+  elseif event.kind == "addSuite" then
+    handle_add_suite(targetName, event)
+  elseif event.kind == "updateSuiteLocation" then
+    handle_update_suite_location(targetName, event)
+  elseif event.kind == "addTestCases" then
+    handle_add_test_cases(targetName, event)
+  else
+    log.error("Unknown event in test explorer", targetName, event)
+  end
+end
+
+local function get_test_suites(test_suite_uri)
+  local test_suites = {}
+  for _, buildTargetState in pairs(state) do
+    for _, test_suite in pairs(buildTargetState) do
+      if test_suite_uri == nil or test_suite.location.uri == test_suite_uri then
+        table.insert(test_suites, test_suite)
+      end
+    end
+  end
+  return test_suites
+end
+
+local function get_test_cases(test_suite)
+  if test_suite.testCases == nil then
+    return {}
+  end
+  local test_cases = {}
+  for _, test_case in pairs(test_suite.testCases) do
+    table.insert(test_cases, test_case)
+  end
+  return test_cases
+end
+
+local function dap_run_test(root, test_suite, test_case)
+  local dap_ok, dap = pcall(require, "dap")
+  if not dap_ok then
+    return log.error_and_show(messages.run_test_without_nvim_dap)
+  end
+  local tests_to_run = {}
+  if test_case ~= nil then
+    tests_to_run = { test_case.name }
+  end
+  local arguments = {
+    type = "scala",
+    request = "launch",
+    name = "Run Test",
+    -- ScalaTestSuitesDebugRequest
+    metals = {
+      target = { uri = "file:" .. root .. "/?id=" .. test_suite.targetName },
+      requestData = {
+        suites = {
+          {
+            className = test_suite.fullyQualifiedClassName,
+            tests = tests_to_run,
+          },
+        },
+        jvmOptions = {},
+        environmentVariables = {},
+      },
+    },
+  }
+  dap.run(arguments)
+end
+
+M.dap_select_test_suite = function(root)
+  local test_suites = get_test_suites(nil)
+  if #test_suites == 0 then
+    return log.warn_and_show(messages.no_test_suites_found)
+  end
+  local test_suite_runner = function(selected_suite)
+    dap_run_test(root, selected_suite, nil)
+  end
+  vim.ui.select(test_suites, {
+    prompt = "Select test suite:",
+    format_item = function(item)
+      return item.fullyQualifiedClassName
+    end,
+  }, test_suite_runner)
+end
+
+M.dap_select_test_case = function(root)
+  local test_suites = get_test_suites(vim.uri_from_bufnr(0))
+  if #test_suites == 0 then
+    return log.warn_and_show(messages.no_test_suites_found)
+  end
+  local test_case_selector = function(selected_suite)
+    local test_cases = get_test_cases(selected_suite)
+    local test_case_runner = function(selected_case)
+      dap_run_test(root, selected_suite, selected_case)
+    end
+    if #test_cases == 0 then
+      log.warn_and_show(messages.no_test_cases_found)
+      return test_case_runner(nil)
+    end
+    vim.ui.select(test_cases, {
+      prompt = "Select test case:",
+      format_item = function(item)
+        return item.name
+      end,
+    }, test_case_runner)
+  end
+
+  vim.ui.select(test_suites, {
+    prompt = "Select test suite:",
+    format_item = function(item)
+      return item.fullyQualifiedClassName
+    end,
+  }, test_case_selector)
+end
+
+M.update_state = function(buildTargetUpdates)
+  for _, buildTagetUpdate in ipairs(buildTargetUpdates) do
+    if state[buildTagetUpdate.targetName] == nil then
+      state[buildTagetUpdate.targetName] = {}
+    end
+    for _, event in ipairs(buildTagetUpdate.events) do
+      handle(buildTagetUpdate.targetName, event)
+    end
+  end
+end
+
+M.state = state
+
+return M


### PR DESCRIPTION
Hey! 
I've been wanting to run individual tests in `nvim-metals` since forever. Finally found some time and tried to do it with test explorer.
Seems like everything is working pretty good for me. 

I added two commands:
-  One for browsing all test suites and running one of them.
- Another one for browsing test suites only in current file and running one test case from selected suite.

Bouth commands can be rerun with `:lua require'dap'.run_last()`.
 
 In order to use it one need to edit metals config like this:
  ```lua
 local metals_config = metals.bare_config()
metals_config.settings = {
  ...
  testUserInterface = "Test Explorer",
}
metals_config.init_options.testExplorerProvider = true
```

Here is a small video of how it works:

https://user-images.githubusercontent.com/14187674/197073732-6696682b-1686-430f-87c0-1dac0844060f.mp4

