### PR TITLE
feat: auto-select the suite when it's the only one

### DIFF
--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -1207,9 +1207,10 @@ current file and the other for testing the entire target. >
     },
   }
 <
-You may also want to use `Select Test Suite` and `Select Test Case` commands
-to run tests. For them to work correctly you should set `testUserInterface`
-setting. This action will deactivate code lenses for test classes. >
+You may also want to use the `Select Test Suite` and `Select Test Case`
+commands to run tests. For them to work correctly you should set the
+`testUserInterface` setting to `"Test Explorer"` as you see below. This action
+will deactivate code lenses for test classes. >
 
   metals_config.settings = {
     testUserInterface = "Test Explorer",

--- a/lua/metals/test_explorer.lua
+++ b/lua/metals/test_explorer.lua
@@ -124,12 +124,20 @@ M.dap_select_test_suite = function()
   local test_suite_runner = function(selected_suite)
     dap_run_test(selected_suite, nil)
   end
-  vim.ui.select(test_suites, {
-    prompt = "Select test suite:",
-    format_item = function(item)
-      return item.fullyQualifiedClassName
-    end,
-  }, test_suite_runner)
+  if #test_suites == 1 then
+    local suite = test_suites[1]
+    log.info_and_show(
+      string.format("Single test suite (%s) found so just running that.", suite.fullyQualifiedClassName)
+    )
+    test_suite_runner(test_suites[1])
+  else
+    vim.ui.select(test_suites, {
+      prompt = "Select test suite:",
+      format_item = function(item)
+        return item.fullyQualifiedClassName
+      end,
+    }, test_suite_runner)
+  end
 end
 
 M.dap_select_test_case = function()
@@ -153,13 +161,16 @@ M.dap_select_test_case = function()
       end,
     }, test_case_runner)
   end
-
-  vim.ui.select(test_suites, {
-    prompt = "Select test suite:",
-    format_item = function(item)
-      return item.fullyQualifiedClassName
-    end,
-  }, test_case_selector)
+  if #test_suites == 1 then
+    test_case_selector(test_suites[1])
+  else
+    vim.ui.select(test_suites, {
+      prompt = "Select test suite:",
+      format_item = function(item)
+        return item.fullyQualifiedClassName
+      end,
+    }, test_case_selector)
+  end
 end
 
 M.update_state = function(buildTargetUpdates)


### PR DESCRIPTION
Just a small feature that I noticed I wanted right away. In the situation where there is only a single suite, don't show the select to choose that single item. Instead, just auto-choose it.

For some reason it's  not letting me assign you as a reviewer @antosha417, but just a heads up. What do you think of this?