### PR TITLE
refactor: don't use file URI in decoded buffer

### DIFF
--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -338,7 +338,7 @@ local function show_decoded(decoder_type, format)
   execute_command({
     command = decoder.command,
     arguments = { metals_uri },
-  }, decoder.make_handler(file_uri, decoder_type, format))
+  }, decoder.make_handler(decoder_type, format))
 end
 
 M.show_build_target_info = function()
@@ -358,7 +358,7 @@ M.show_build_target_info = function()
           execute_command({
             command = decoder.command,
             arguments = { metals_uri },
-          }, decoder.make_handler(root, decoder.types.build_target))
+          }, decoder.make_handler(decoder.types.build_target))
         end
       end)
     else

--- a/lua/metals/decoder.lua
+++ b/lua/metals/decoder.lua
@@ -26,7 +26,7 @@ local function filename_from_uri(full_uri)
   return parts[#parts]
 end
 
-local handle_decoder_response = function(result, uri, decoder, format)
+local handle_decoder_response = function(result, decoder, format)
   if result.error then
     local err = result.error or result.value
     log.error_and_show(err)
@@ -39,7 +39,7 @@ local handle_decoder_response = function(result, uri, decoder, format)
     )
     log.error_and_show("This shouldn't happen. Please check the logs and report a bug that you saw this.")
   elseif result.value then
-    local filename = filename_from_uri(uri)
+    local filename = filename_from_uri(result.requestedUri)
     local name = string.format("%s %s %s viewer", filename, format or "", decoder)
     local cwd = fn.getcwd()
 
@@ -82,13 +82,13 @@ local handle_decoder_response = function(result, uri, decoder, format)
   -- cancells the quickpick so we only return the uri, not result, no err.
 end
 
-local make_handler = function(uri, decoder, format)
+local make_handler = function(decoder, format)
   return function(err, _, result)
     if err then
       log.error_and_show(string.format("Something went wrong trying to get %s. Please check the logs.", decoder))
       log.error(err)
     else
-      handle_decoder_response(result, uri, decoder, format)
+      handle_decoder_response(result, decoder, format)
     end
   end
 end
@@ -96,7 +96,6 @@ end
 return {
   command = "metals.file-decode",
   formats = formats,
-  handle_decoder_response = handle_decoder_response,
   make_handler = make_handler,
   metals_decode = "metalsDecode",
   types = types,


### PR DESCRIPTION
Instead of just using the fileUri instead of the name we give the buffer while using the decoder feature we instead can use the requestedUri that is returned with the decoded response. This is unique for each class in a file and for each build target. This way you can now view 2 different classes in the same file with no issue.

Fixes #459