### PR TITLE
feat: add a generic commands method using vim.ui.select

### DIFF
--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -766,6 +766,17 @@ bare_config()
                            tvp settings. Use this when setting up settings for
                            `nvim-metals` to pass into |initialize_or_attach()|.
 
+commands()                                                           *commands()*
+                           Gives the users all the available |metals-commands|
+                           utilizing |vim.ui.select()|. If you're a telescope
+                           user you can choose to use this with something like
+                           https://github.com/stevearc/dressing.nvim or feel
+                           free to use the built-in telescope extension
+                           |metals-telescope| which just displays things a bit
+                           better since we have more control over using
+                           |vim.ui.select()|. If you're not a telescope user,
+                           then you'll want to use this.
+
                                                                *compile_cancel()*
 compile_cancel()           Use to execute a |metals.compile-cancel| command.
 
@@ -1240,5 +1251,8 @@ longer be lazy loaded. >
   require("telescope").extensions.metals.commands()
 
 <
+
+NOTE: If you'd rather utilize |vim.ui.select| for this a more generate
+|commands()| is available in the |metals-lua-api|.
 
 vim:tw=80:ts=2:ft=help:

--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -2,6 +2,7 @@ local api = vim.api
 local fn = vim.fn
 local lsp = vim.lsp
 
+local commands = require("metals.commands")
 local conf = require("metals.config")
 local decoder = require("metals.decoder")
 local decoration = require("metals.decoration")
@@ -472,6 +473,19 @@ end
 
 M.select_test_case = function()
   test_explorer.dap_select_test_case()
+end
+
+M.commands = function()
+  vim.ui.select(commands.commands_table, {
+    prompt = "Metals Commands",
+    format_item = function(item)
+      return item.label
+    end,
+  }, function(item)
+    if item ~= nil then
+      M[item.id]()
+    end
+  end)
 end
 
 return M


### PR DESCRIPTION
This can be used as an alternative to the telescope extension or for non
telescope uses to have the same type of functionality using whatever the
like for `vim.ui.select`.
