### PR TITLE
feat: add in bleep.yaml as a default root pattern.

### DIFF
--- a/lua/metals/config.lua
+++ b/lua/metals/config.lua
@@ -316,7 +316,7 @@ local function validate_config(config, bufnr)
   -- custom patters to be passed in without doing the entire root_dir logic
   -- yourself.
   config.root_patterns = config.root_patterns
-    or { "build.sbt", "build.sc", "build.gradle", "pom.xml", ".scala-build", ".git" }
+    or { "build.sbt", "build.sc", "build.gradle", "pom.xml", ".scala-build", "bleep.yaml", ".git" }
 
   local bufname = api.nvim_buf_get_name(bufnr)
 


### PR DESCRIPTION
This will help https://bleep.build/ users
