### PR TITLE
refactor: change toggle_logs to open a new tab

### DIFF
--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -988,12 +988,9 @@ super_method_hierarchy()   Use to execute a |metals.super-method-hierarchy|
 switch_bsp()               Use to execute a |metals.bsp-switch| command.
 
                                                                   *toggle_logs()*
-toggle_logs({direction})   Use to trigger a `tail -f .metals/log` on your
+toggle_logs()              Use to trigger a `tail -f .metals/log` on your
                            current workspace that will open in the embedded
-                           Neovim terminal.
-
-                           Parameters: {direction} (string) This can either be
-                           vsp to split vertically or sp for a horizontal split.
+                           Neovim terminal in a new tab.
 
                                                                *toggle_setting()*
 toggle_setting({setting})

--- a/lua/metals/config.lua
+++ b/lua/metals/config.lua
@@ -165,17 +165,11 @@ local commands = {}
 -- Doesn't really fit in here, but we need to use it for the commands down below
 -- and also in metals.lua, so to avoid a cyclical dep we just put it in here
 local function toggle_logs(direction)
-  local bufs = api.nvim_list_bufs()
-  local split_direction = "vsp"
-
   if direction then
-    if direction ~= "vsp" and direction ~= "sp" then
-      log.error_and_show("direction must be able vsp or sp")
-      return
-    else
-      split_direction = direction
-    end
+    log.warn_and_show("toggle_logs no longer takes a parameter. Please remove it.")
   end
+
+  local bufs = api.nvim_list_bufs()
 
   for _, buf in ipairs(bufs) do
     local buftype = api.nvim_buf_get_option(buf, "buftype")
@@ -185,7 +179,7 @@ local function toggle_logs(direction)
       if first_window_id then
         fn.win_gotoid(first_window_id)
       else
-        api.nvim_command(string.format("%s | :b %i", split_direction, buf))
+        api.nvim_command(string.format("tabnew +buf\\ %s", buf))
       end
 
       return
@@ -195,7 +189,7 @@ local function toggle_logs(direction)
   -- Only open them if a terminal isn't already open
   -- -n here allows for the last 100 lines to also be shown.
   -- Useful if you hit on an issue and first then toggle the logs.
-  api.nvim_command(string.format([[%s +set\ ft=log term://tail -n 100 -f .metals/metals.log]], split_direction))
+  api.nvim_command([[tabnew +set\ ft=log term://tail -n 100 -f .metals/metals.log]])
   vim.b["metals_buf_purpose"] = "logs"
 end
 


### PR DESCRIPTION
I recently used `:LspLog` and really liked how it opened in a new tab. I
feel like this is the way to go instead of trying to do a `sp` or `vsp`.
This pr changes `toggle_logs` to now no longer take a direction, but to
instead just open a new tab.
