### PR TITLE
fix(test): ensure diagnostic focus test works

### DIFF
--- a/tests/tests/handlers/execute_client_command_spec.lua
+++ b/tests/tests/handlers/execute_client_command_spec.lua
@@ -3,28 +3,15 @@ local handlers = require("metals.handlers")
 describe("metals/executeClientCommand", function()
   it("handles metals-diagnostics-focus", function()
     local bufs_before = vim.api.nvim_list_bufs()
-
-    local captured_msg
-
-    vim.notify = function(...)
-      local msg = select(1, ...)
-      captured_msg = msg
-    end
+    local buf = bufs_before[1]
+    local namespace = vim.api.nvim_create_namespace("metals")
+    vim.diagnostic.set(namespace, buf, { { lnum = 1, col = 1, message = "hoi" } }, {})
 
     handlers["metals/executeClientCommand"](nil, { command = "metals-diagnostics-focus" })
 
-    -- A litte bit of shinanigans here because the behavion in 0.8.0 and nightly is
-    -- slightly different whereas in nighly, since there is no errors this will just
-    -- notify youthat there are no diagnostics. However in 0.8.0 this would open a qf
-    -- window even if there was 0 diagnostics. So we first check if notify was called,
-    -- and if so, check the messaage (nightly) else we go back and check the buffer count.
-    if captured_msg then
-      assert.are.same("No diagnostics available", captured_msg)
-    else
-      local bufs_after = vim.api.nvim_list_bufs()
-      -- Another buffer should be open after the call since we opened the diagnostic window
-      assert.are.same(#bufs_before + 1, #bufs_after)
-    end
+    local bufs_after = vim.api.nvim_list_bufs()
+    -- Another buffer should be open after the call since we opened the diagnostic window
+    assert.are.same(#bufs_before + 1, #bufs_after)
   end)
 
   it("handles metals-goto-location", function()


### PR DESCRIPTION
Nightly changed this yet again, so we'll no longer get the
'No diagnostics set' message, but the window also still won't
open. So this change actually creates a diagnostic for the window
to ensure that when the metals-diagnostic-focus comes it, it opens
up.
