### PR TITLE
Only send codeAction to metals when organizing imports

### DIFF
--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -293,13 +293,15 @@ M.find_in_dependency_jars = function()
 end
 
 M.organize_imports = function()
+  local lsp_clients = lsp.get_active_clients({ bufnr = 0, name = "metals" })
+  if not lsp_clients or vim.tbl_isempty(lsp_clients) then
+    log.warn("metals is not active for this buffer")
+    return
+  end
+  local metals_client = lsp_clients[1]
+
   local params = lsp.util.make_range_params()
   params.context = { diagnostics = {}, only = { "source.organizeImports" } }
-  local lsp_clients = lsp.get_active_clients({ bufnr = 0, name = "metals" })
-  local metals_client = {}
-  for _, client in pairs(lsp_clients) do
-    metals_client = client
-  end
 
   local response = metals_client.request_sync("textDocument/codeAction", params, 1000, 0)
   if not response or vim.tbl_isempty(response) then

--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -295,7 +295,7 @@ end
 M.organize_imports = function()
   local lsp_clients = lsp.get_active_clients({ bufnr = 0, name = "metals" })
   if not lsp_clients or vim.tbl_isempty(lsp_clients) then
-    log.warn("metals is not active for this buffer")
+    log.warn_and_show("Metals is attatched to this buffer, so unable to organize imports.")
     return
   end
   local metals_client = lsp_clients[1]

--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -295,7 +295,7 @@ end
 M.organize_imports = function()
   local params = lsp.util.make_range_params()
   params.context = { diagnostics = {}, only = { "source.organizeImports" } }
-  local lsp_clients = lsp.get_active_clients({ bufnr = 0, name = 'metals' })
+  local lsp_clients = lsp.get_active_clients({ bufnr = 0, name = "metals" })
   local metals_client = {}
   for _, client in pairs(lsp_clients) do
     metals_client = client

--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -295,19 +295,22 @@ end
 M.organize_imports = function()
   local params = lsp.util.make_range_params()
   params.context = { diagnostics = {}, only = { "source.organizeImports" } }
-  local resp = lsp.buf_request_sync(0, "textDocument/codeAction", params, 1000)
+  local lsp_clients = lsp.get_active_clients({ bufnr = 0, name = 'metals' })
+  local metals_client = {}
+  for _, client in pairs(lsp_clients) do
+    metals_client = client
+  end
 
-  if not resp or vim.tbl_isempty(resp) then
+  local response = metals_client.request_sync("textDocument/codeAction", params, 1000, 0)
+  if not response or vim.tbl_isempty(response) then
     return
   end
 
-  for _, response in pairs(resp) do
-    for _, result in pairs(response.result or {}) do
-      if result.edit then
-        lsp.util.apply_workspace_edit(result.edit, "utf-16")
-      else
-        lsp.buf.execute_command(result.command)
-      end
+  for _, result in pairs(response.result or {}) do
+    if result.edit then
+      lsp.util.apply_workspace_edit(result.edit, "utf-16")
+    else
+      lsp.buf.execute_command(result)
     end
   end
 end


### PR DESCRIPTION
The telescope - organize imports command doesn't work for me when I also have null-ls setup with the gitsigns integration. The problem seems to be twofold:
1. All language servers are sent `textDocument/codeAction` when formatting
2. When executing the responses to 1., I think the wrong object is passed to `vim.lsp.buf.execute_command`

I tried replacing `lsp.buf.execute_command(result.command)` with `lsp.buf.execute_command(result)`, which did make stuff happen when I ran "Organize imports", but my buffer ended up empty. Not really sure how the different actions interact to make that happen :sweat_smile: 

So I tried limiting the "Organize imports" command to only send the request to the metals language server. That seems to have fixed it.

-----------

I have very little experience with lua, but I hope this helps anyhow :-)