### PR TITLE
refactor: make error for null in reveal in tree better

### DIFF
--- a/lua/metals/messages.lua
+++ b/lua/metals/messages.lua
@@ -58,4 +58,9 @@ M.run_test_without_nvim_dap = [[
 You can not run test without `nvim-dap` being installed.
 Please make sure `mfussenegger/nvim-dap` is installed.]]
 
+M.scala_3_tree_view = [[
+You recieved a null response for the tree view.
+If you're using Scala 3, this is expected as it's not support yet.
+If you're using Scala 3, please create an issue for this in nvim-metals.]]
+
 return M

--- a/lua/metals/tvp/init.lua
+++ b/lua/metals/tvp/init.lua
@@ -2,6 +2,7 @@ local api = vim.api
 local lsp = vim.lsp
 
 local log = require("metals.log")
+local messages = require("metals.messages")
 local Node = require("metals.tvp.node")
 local tvp_util = require("metals.tvp.util")
 local util = require("metals.util")
@@ -453,8 +454,8 @@ local function reveal_in_tree()
     vim.lsp.buf_request(valid_metals_buffer(), "metals/treeViewReveal", params, function(err, result, ctx)
       if err then
         log.error_and_show(string.format("Error when executing: %s. Check the metals logs for more info.", ctx.method))
-      else
-        if result and result.viewId == metals_packages then
+      elseif result then
+        if result.viewId == metals_packages then
           if api.nvim_get_current_win() ~= state.tvp_tree.win_id then
             vim.fn.win_gotoid(state.tvp_tree.win_id)
           end
@@ -470,8 +471,12 @@ local function reveal_in_tree()
             focus = true,
           })
         else
-          log.warn_and_show("You recieved a node for a view nvim-metals doesn't support")
+          log.warn_and_show(
+            string.format("You recieved a node for a view nvim-metals doesn't support: %s", result.viewId)
+          )
         end
+      else
+        log.warn_and_show(messages.scala_3_tree_view)
       end
     end)
   end)


### PR DESCRIPTION
This will hopefully give the user a bit more information about what is
happening when they receive a `null` from the tree view. Since it's not
supported yet in Scala 3 this may happen. So in that situation we tell
them that and also let them know that if they are in Scala 2 they should
create an issue. We also better catch the situation where they truly get
a view id that isn't supported. In that case we show them what id it is.

Closes #546
