### PR TITLE
fix: make sure floats are marked as readOnly

### DIFF
--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -194,6 +194,7 @@ M.info = function()
     api.nvim_buf_set_option(float.bufnr, "filetype", "markdown")
     api.nvim_buf_set_lines(float.bufnr, 0, -1, false, output)
     api.nvim_buf_set_keymap(float.bufnr, "n", "q", "<cmd>close!<CR>", { nowait = true, noremap = true, silent = true })
+    api.nvim_buf_set_option(float.bufnr, "readonly", true)
   end
 end
 

--- a/lua/metals/doctor.lua
+++ b/lua/metals/doctor.lua
@@ -134,6 +134,7 @@ Doctor.create = function(args)
   api.nvim_buf_set_option(float.bufnr, "filetype", "markdown")
   api.nvim_buf_set_lines(float.bufnr, 0, -1, false, output)
   api.nvim_buf_set_keymap(float.bufnr, "n", "q", "<cmd>close!<CR>", { nowait = true, noremap = true, silent = true })
+  api.nvim_buf_set_option(float.bufnr, "readonly", true)
 
   api.nvim_create_autocmd("WinLeave", {
     buffer = float.bufnr,


### PR DESCRIPTION
I noticed recently when doing a `:MetalsInfo` that you could edit the
window. This isn't needed or desired. This changes make sure that both
the info and the doctor windows are marked as readonly.
