### PR TITLE
Better "Restart X" command names

### DIFF
--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -952,11 +952,11 @@ quick_worksheet()          Create a quick worksheet in your current dir with
                                                                  *reset_choice()*
 reset_choice()             Use to execute a |metals.reset-choice| command.
 
-                                                                *restart_build()*
-restart_build()            Use to execute a |metals.build-restart| command.
+                                                         *restart_build_server()*
+restart_build_server()     Use to execute a |metals.build-restart| command.
 
-                                                               *restart_server()*
-restart_server()           Restart the Metals server.
+                                                               *restart_metals()*
+restart_metals()           Restart the Metals server.
 
                                                                    *run_doctor()*
 run_doctor()               Use to execute a |metals.doctor-run| command.

--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -76,7 +76,7 @@ M.import_build = function()
   execute_command({ command = "metals.build-import" })
 end
 
-M.restart_build = function()
+M.restart_build_server = function()
   execute_command({ command = "metals.build-restart" })
 end
 
@@ -321,7 +321,7 @@ end
 
 -- Used to fully restart Metals. This will send a shutdown request to Metals,
 -- delay for 3 seconds, and then reconnect.
-M.restart_server = function()
+M.restart_metals = function()
   for _, buf in pairs(fn.getbufinfo({ bufloaded = true })) do
     if vim.tbl_contains(conf.scala_file_types, api.nvim_buf_get_option(buf.bufnr, "filetype")) then
       local clients = lsp.get_active_clients({ buffer = buf.bufnr, name = "metals" })

--- a/lua/metals/commands.lua
+++ b/lua/metals/commands.lua
@@ -108,14 +108,14 @@ local commands_table = {
     hint = "Reset a specific choice.",
   },
   {
-    id = "restart_build",
-    label = "Restart Build",
+    id = "restart_build_server",
+    label = "Restart Build Server",
     hint = "Restart the current build server.",
   },
   {
-    id = "restart_server",
-    label = "Restart Server",
-    hint = "Restart Metals",
+    id = "restart_metals",
+    label = "Restart Metals",
+    hint = "Restart Metals server.",
   },
   {
     id = "run_doctor",


### PR DESCRIPTION
Addresses https://github.com/scalameta/nvim-metals/issues/551
`restart_server` is renamed to `restart_metals`
`restart_build` is renamed to `restart_build_server`
