### PR TITLE
!chore: start requiring 0.9.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        neovim_version: ['v0.8.0', 'nightly']
+        neovim_version: ['v0.9.0', 'nightly']
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ the available features
 
 ## Prerequisites
 
-- Before you get started you need to ensure that you are using nvim v.0.8.0 or
-    newer. If you're still on v0.7.x then you'll want to target the `v0.7.x`
+- Before you get started you need to ensure that you are using nvim v.0.9.0 or
+    newer. If you're still on v0.8.x then you'll want to target the `v0.8.x`
     tag.
 - Ensure [Coursier](https://get-coursier.io/docs/cli-installation) is
     installed locally.[^coursier]


### PR DESCRIPTION
Nothing is actually breaking on this commit, but moving forward there
will be changes that require 0.9.x. So make sure you're on the latest
0.9 release.
