### PR TITLE
refactor: start using lua-version api

### DIFF
--- a/lua/metals/install.lua
+++ b/lua/metals/install.lua
@@ -80,36 +80,12 @@ end
 local function scala_version_for_install(server_version)
   local default = "2.13"
 
-  local function inspect_version(version)
-    local parts = util.split_on(version, "%.")
-    -- Major is > 0
-    if tonumber(parts[1]) > 0 then
-      return default
-      -- Major == 0 and Minor > 11
-    elseif tonumber(parts[2]) > 11 then
-      return default
-      -- Major == 0 and Minor == 11
-    elseif tonumber(parts[2]) == 11 then
-      -- If it contains SNAPSHOT just go 2.13
-      if parts[3]:find("SNAPSHOT") ~= nil then
-        return default
-        -- If PATCH is a vlid number and > 2
-      elseif tonumber(parts[3]) ~= nil and tonumber(parts[3]) > 2 then
-        return default
-      else
-        -- Either version is wonky and can't parse or it's 0 or 1
-        return "2.12"
-      end
-    else
-      -- All else fails just go 2.13
-      return default
-    end
-  end
-
   if server_version == latest_stable or server_version == latest_snapshot then
     return default
+  elseif vim.version.gt(vim.version.parse(server_version), vim.version.parse("0.11.2")) then
+    return default
   else
-    return inspect_version(server_version)
+    return "2.12"
   end
 end
 

--- a/tests/setup/install_spec.lua
+++ b/tests/setup/install_spec.lua
@@ -34,7 +34,7 @@ describe("install", function()
 
   it("should be able to install with a new 2.13 snapshot", function()
     local bare_config = require("metals.setup").bare_config()
-    bare_config.settings = { serverVersion = "0.11.2+3-105f3501-SNAPSHOT" }
+    bare_config.settings = { serverVersion = "0.11.12+30-c205bbc9-SNAPSHOT" }
     config.validate_config(bare_config, vim.api.nvim_get_current_buf())
 
     eq(path:exists(), false)

--- a/tests/tests/install_version_spec.lua
+++ b/tests/tests/install_version_spec.lua
@@ -23,13 +23,6 @@ describe("install_version", function()
     eq("2.13", binary_version)
   end)
 
-  it("should be able to know that 0.11.3 needs 2.13", function()
-    local server_version = "0.11.3"
-
-    local binary_version = install._scala_version_for_install(server_version)
-    eq("2.13", binary_version)
-  end)
-
   it("should be able to know that 0.11.11 needs 2.13", function()
     local server_version = "0.11.11"
 


### PR DESCRIPTION
This allows me to get rid of some of the hacky stuff I was doing to
compare versions to know if we should be pulling 2.12 or 2.13.
