### PR TITLE
feat: use current range for `type_of_range()`

### DIFF
--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -434,7 +434,26 @@ M.run_scalafix = function()
 end
 
 M.type_of_range = function()
-  vim.lsp.buf_request(0, "textDocument/hover", vim.lsp.util.make_given_range_params())
+  local range_start = vim.fn.getpos('v')
+  local range_end = vim.fn.getcurpos()
+
+  local range_start_row = range_start[2]
+  local range_start_col = range_start[3]
+  local range_end_row = range_end[2]
+  local range_end_col = range_end[3]
+
+  local start_pos
+  local end_pos
+
+  if range_end_row < range_start_row or (range_start_row == range_end_row and range_start_col > range_end_col) then 
+      start_pos = {range_end_row, range_end_col}
+      end_pos = {range_start_row, range_start_col-1}
+  else
+      start_pos = {range_start_row, range_start_col}
+      end_pos = {range_end_row, range_end_col-1}
+  end
+
+  vim.lsp.buf_request(0, "textDocument/hover", vim.lsp.util.make_given_range_params(start_pos, end_pos))
 end
 
 -- Since we want metals to be the entrypoint for everything, just for ensure that it's


### PR DESCRIPTION
Adds better support for https://github.com/scalameta/metals/pull/3060.

Context:
* https://github.com/neovim/neovim/issues/15905
---

Currently, `vim.lsp.util.make_given_range_params()` defaults to previous selection as it's using  '< and '> registers underneath ([code](https://github.com/neovim/neovim/blob/4e5061dba765df2a74ac4a8182f6e7fe21da125d/runtime/lua/vim/lsp/util.lua#L2044:L2045)) which are only updated after leaving visual mode. While it might be useful in some cases, using it for `type_of_range()`  leads to unresponsive experience.

In the new implementation we use [getpos()](https://neovim.io/doc/user/builtin.html#getpos()) and [getcurpos()](https://neovim.io/doc/user/builtin.html#getcurpos()) which returns position that is updated live as selection changes.

Showcase:

https://github.com/scalameta/nvim-metals/assets/33397865/92ccab09-b3d5-4011-a39f-a237e6169a76