### PR TITLE
fix: use the default value in metals/inputBox

### DIFF
--- a/lua/metals/handlers.lua
+++ b/lua/metals/handlers.lua
@@ -30,7 +30,13 @@ end
 -- Implementation of the `metals/inputBox` Metals LSP extension.
 -- https://scalameta.org/metals/docs/integrations/new-editor#metalsinputbox
 M["metals/inputBox"] = function(_, result)
-  local name = vim.fn.input(result.prompt .. ": ")
+  local args = { prompt = result.prompt .. "\n" }
+
+  if result.value then
+    args.default = result.value
+  end
+
+  local name = vim.fn.input(args)
 
   if name == "" then
     return { cancelled = true }


### PR DESCRIPTION
Currently when we would get a `value` inside of the inputBox params we
didn't use it as the default when we could have been.
