### PR TITLE
fix: add a check if the release file exists

### DIFF
--- a/lua/metals/config.lua
+++ b/lua/metals/config.lua
@@ -361,16 +361,20 @@ local function validate_config(config, bufnr)
       return nil
     else
       local release = Path:new(java_home, "release")
-      local version_line
-      for line in io.lines(release.filename) do
-        if util.starts_with(line, "JAVA_VERSION") then
-          version_line = line
-          break
+      if release:exists() then
+        local version_line
+        for line in io.lines(release.filename) do
+          if util.starts_with(line, "JAVA_VERSION") then
+            version_line = line
+            break
+          end
         end
-      end
 
-      local version = vim.version.parse(version_line:sub(14, version_line:len()))
-      return version
+        local version = vim.version.parse(version_line:sub(14, version_line:len()))
+        return version
+      else
+        return nil
+      end
     end
   end
 


### PR DESCRIPTION
As of 34a82230 we added in a check to get the version out of the release
file. Now we also make sure that the file actually exists before doing
the check.

Closes #577
