### PR TITLE
Tweaked find_root_dir to accept a configurable max # of grandparents

### DIFF
--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -895,6 +895,21 @@ initialize_or_attach({config})
                               {'build.sbt', 'build.sc', 'build.gradle',
                               'pom.xml', '.git'}
 <
+
+                           By default, when Metals detects a valid root_dir,
+                           it will check 1 folder up to see if there is a
+                           valid "parent" project above it. If you have a
+                           more complex project with multiple nested sub-
+                           projects, set the `find_root_dir_max_project_nesting`
+                           key to an integer greater than 1.
+                           Ex: Set `find_root_dir_max_project_nesting` to 2 if
+                           this is your project tree:
+                           build.sbt <- this is the desired root
+                             a/
+                               b/
+                                 - build.sbt <- subproject, not the desired root
+                                 - src/main/scala/Main.scala
+
                            If you need even more fine-grained control over
                            finding your root-dir (in cases where you have very
                            uncommon build layouts) you can also use the

--- a/lua/metals/config.lua
+++ b/lua/metals/config.lua
@@ -319,7 +319,11 @@ local function validate_config(config, bufnr)
 
   local find_root_dir = config.find_root_dir or root_dir.find_root_dir
 
-  config.root_dir = find_root_dir(config.root_patterns, bufname) or fn.expand("%:p:h")
+  -- Maximum parent folders to search AFTER the first project file (e.g. build.sbt) was found
+  local find_root_dir_max_project_nesting = config.find_root_dir_max_project_nesting or 2
+
+  config.root_dir = find_root_dir(config.root_patterns, bufname, find_root_dir_max_project_nesting)
+    or fn.expand("%:p:h")
 
   local base_handlers = vim.tbl_extend("error", default_handlers, tvp.handlers)
 

--- a/lua/metals/config.lua
+++ b/lua/metals/config.lua
@@ -320,7 +320,7 @@ local function validate_config(config, bufnr)
   local find_root_dir = config.find_root_dir or root_dir.find_root_dir
 
   -- Maximum parent folders to search AFTER the first project file (e.g. build.sbt) was found
-  local find_root_dir_max_project_nesting = config.find_root_dir_max_project_nesting or 2
+  local find_root_dir_max_project_nesting = config.find_root_dir_max_project_nesting or 1
 
   config.root_dir = find_root_dir(config.root_patterns, bufname, find_root_dir_max_project_nesting)
     or fn.expand("%:p:h")

--- a/lua/metals/rootdir.lua
+++ b/lua/metals/rootdir.lua
@@ -21,7 +21,7 @@ end
 ---  - build.sbt <- this is not
 ---  - src/main/scala/Main.scala
 --- If your projects are multiple layers deep, set
---- config.find_root_dir_max_project_nesting to a greater number. Default is 2
+--- config.find_root_dir_max_project_nesting to a greater number. Default is 1
 --- for the behavior described above.
 local find_root_dir = function(patterns, startpath, maxParentSearch)
   local path = Path:new(startpath)
@@ -32,7 +32,7 @@ local find_root_dir = function(patterns, startpath, maxParentSearch)
 
   for i, parent in ipairs(path:parents()) do
     -- Exit loop before checking anything if we've exceeded the search limits
-    if firstFoundIdx >= 0 and (i - firstFoundIdx >= maxParentSearch) then
+    if firstFoundIdx >= 0 and (i - firstFoundIdx > maxParentSearch) then
       return ret
     end
     local pattern = has_pattern(patterns, parent)

--- a/tests/tests/root_dir_spec.lua
+++ b/tests/tests/root_dir_spec.lua
@@ -36,6 +36,18 @@ else
       )
     end)
 
+    it("should correctly find the root in an odly nested multi-build sbt project", function()
+      local expected = multi_build_example:expand()
+      eq(
+        expected,
+        root_dir.find_root_dir(
+          { "build.sbt" },
+          Path:new(multi_build_example:expand(), "other", "nested", "src", "main", "scala", "example", "Hello.scala").filename,
+          2 -- set to two here because we want to skip the other/nested/buid.sbt
+        )
+      )
+    end)
+
     it("should correctly find the root in a minimal mill build", function()
       local expected = mill_minimal:expand()
       eq(

--- a/tests/tests/root_dir_spec.lua
+++ b/tests/tests/root_dir_spec.lua
@@ -17,7 +17,7 @@ if not (multi_build_example:exists()) or not (mill_minimal:exists()) or not (sca
 else
   describe("The find root dir functionality", function()
     it("should return nil when no pattern is detected", function()
-      local result = root_dir.find_root_dir({ "build.sbt" }, Path:new("."):expand()) or "was_nil"
+      local result = root_dir.find_root_dir({ "build.sbt" }, Path:new("."):expand(), 1) or "was_nil"
       -- We expect nil here because nvim-metals has logic to then catch this nil and return the file that was opened.
       -- No idea why but locally using nil here works fine by in Linux CI nil here keeps thinking I'm only using
       -- one argument, so we instead replace it with "was_nil" which makes CI happy. who knows.
@@ -30,7 +30,8 @@ else
         expected,
         root_dir.find_root_dir(
           { "build.sbt" },
-          Path:new(multi_build_example:expand(), "core", "src", "main", "scala", "example", "Hello.scala").filename
+          Path:new(multi_build_example:expand(), "core", "src", "main", "scala", "example", "Hello.scala").filename,
+          1
         )
       )
     end)
@@ -41,7 +42,8 @@ else
         expected,
         root_dir.find_root_dir(
           { "build.sc" },
-          Path:new(mill_minimal:expand(), "MillMinimal", "src", "example", "Hello.scala").filename
+          Path:new(mill_minimal:expand(), "MillMinimal", "src", "example", "Hello.scala").filename,
+          1
         )
       )
     end)
@@ -52,7 +54,8 @@ else
       local expected = Path:new(scala_cli:expand(), "src").filename
       local result = root_dir.find_root_dir(
         { ".scala", ".scala-build", ".git" },
-        Path:new(scala_cli:expand(), "src", "Main.scala").filename
+        Path:new(scala_cli:expand(), "src", "Main.scala").filename,
+        1
       )
       eq(expected, result)
     end)


### PR DESCRIPTION
With this change, users can now set `config.find_root_dir_max_project_nesting` to an integer if you want to override the default # of parents.

Related to discussion #584

Note: It doesn't have to use recursion, since it was already looping through a finite list of parent folders, one at a time.

Second note: I didn't write any tests since I'm not sure how to set those up. I did test it myself in my own project. **(Running `make tests` failed on my system.)** What I'd probably do is set up a folder tree like this:

testdir/
  - build.sbt
  - a/
    - build.sbt
    - b/
      - build.sbt
      - c/
        - build.sbt
        - src/main/scala/Main.scala

and set `config.find_root_dir_max_project_nesting` to values between 0 and 4, with the following expectations:
0: root_dir = `testdir/a/b/c/build.sbt`
1: root_dir = `testdir/a/b/build.sbt`
2: root_dir = `testdir/a/build.sbt`
3: root_dir = `testdir/build.sbt`
4: root_dir = `testdir/build.sbt` (same as 3 because it's the max)

Additionally, setting it to something like 20 would be useful to guarantee that it doesn't break when it reaches the filesystem root.

Third note: I'm pretty sure this won't break on systems where people already overwrote their own find_root_dir, since Lua seems to not care when you add extra parameters to the function (find_root_dir now takes `find_root_dir_max_project_nesting` as a third parameter, but people who overwrote it will not have a third parameter, so for them, it should just ignore the third parameter)