### PR TITLE
fix: revert the need for extra flags for 17

### DIFF
--- a/lua/metals/config.lua
+++ b/lua/metals/config.lua
@@ -355,41 +355,7 @@ local function validate_config(config, bufnr)
 
   local passed_in_options = config.settings.metals.serverProperties or {}
 
-  local get_java_version = function(java_home)
-    java_home = java_home or os.getenv("JAVA_HOME")
-    if java_home == nil then
-      return nil
-    else
-      local release = Path:new(java_home, "release")
-      if release:exists() then
-        local version_line
-        for line in io.lines(release.filename) do
-          if util.starts_with(line, "JAVA_VERSION") then
-            version_line = line
-            break
-          end
-        end
-
-        local version = vim.version.parse(version_line:sub(14, version_line:len()))
-        return version
-      else
-        return nil
-      end
-    end
-  end
-
-  local java_version = get_java_version(config.settings.metals.javaHome)
-
-  local extra_java_opts = {}
-  if java_version and vim.version.gt(java_version, { 17, 0, 0 }) then
-    extra_java_opts = {
-      "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
-      "--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-      "--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
-    }
-  end
-
-  local all_opts = util.merge_lists(util.merge_lists(passed_in_options, valid_java_opts), extra_java_opts)
+  local all_opts = util.merge_lists(passed_in_options, valid_java_opts)
 
   for i, opt in ipairs(all_opts) do
     -- In order to pass these options to coursier they need to be prefaced with `-J`


### PR DESCRIPTION
This is no longer needed as of https://github.com/scalameta/metals/pull/5375. You can see more context for this in https://github.com/scalameta/metals/pull/5453#discussion_r1266358730.
