### PR TITLE
Update doc about enableSemanticHighlighting

### DIFF
--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -473,7 +473,7 @@ parent/super methods of members.
 enableSemanticHighlighting                          *enableSemanticHighlighting* 
 
 Type: boolean ~
-Default: false ~
+Default: true ~
 
 When this option is enabled, Metals will provide semantic tokens for clients
 that support it. The feature is still experimental and does not work for


### PR DESCRIPTION
Following the discussion in https://github.com/scalameta/nvim-metals/discussions/603 I have opened this PR as a reminder to myself to take of that.
I am sure that we could update the description as well but I'm wondering if this documentation is taken from elsewhere, I also need to double check if any other options/default changed in order to include the changes in that PR.

