### PR TITLE
fix: avoid crash when there is no selection

### DIFF
--- a/lua/telescope/_extensions/metals.lua
+++ b/lua/telescope/_extensions/metals.lua
@@ -22,8 +22,8 @@ local pickers = require("telescope.pickers")
 local function execute_command(bufnr)
   local selection = action_state.get_selected_entry(bufnr)
   actions.close(bufnr)
-  local cmd = selection.command
-  if cmd then
+  if selection then
+    local cmd = selection.command
     local success, msg = pcall(cmd)
     if not success then
       vim.api.nvim_notify(msg, 2, {})


### PR DESCRIPTION
This just changes the guard here to make sure that if the user
doesn't select anything with the telescope extension that instead
of crashing we just do nothing.

Fixes #606
