### PR TITLE
chore(ci): test against 0.9.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        neovim_version: ['v0.9.0', 'nightly']
+        neovim_version: ['v0.9.2', 'nightly']
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ the available features
 
 ## Prerequisites
 
-- Before you get started you need to ensure that you are using nvim v.0.9.0 or
-    newer. If you're still on v0.8.x then you'll want to target the `v0.8.x`
-    tag.
+- Before you get started you need to ensure that you are using the latest nvim
+v.0.9.x or newer. If you're still on v0.8.x then you'll want to target the
+`v0.8.x` tag.
 - Ensure [Coursier](https://get-coursier.io/docs/cli-installation) is
     installed locally.[^coursier]
 - Ensure that you have all the LSP mappings for the core functionality you want


### PR DESCRIPTION
Previously this was testing against 0.9.0 but we now target 0.9.2 and I also added a note about supporting the latest version of 0.9.x