### PR TITLE
!fix: rename bsp_status to metals_bsp_status

### DIFF
--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -110,6 +110,11 @@ enable the `statusBarProvider` like shown below: >
   metals_config.init_options.statusBarProvider = "on"
 <
 
+You can also get extra status information from Metals about your BSP
+connection. You can access this with `vim.g['metals_bsp_status']`. This will
+either return useful messages from your build server about things like
+disconnects or just the name of the build server being used.
+
 Then instead of passing an empty `{}` to |initialize_or_attach()|, you'd pass
 in `metals_config`.
 

--- a/lua/metals/status.lua
+++ b/lua/metals/status.lua
@@ -4,7 +4,16 @@ local log = require("metals.log")
 local function set_status(status, type)
   -- Scaping the status to prevent % characters breaking the statusline
   local scaped_status = status:gsub("[%%]", "%%%1")
-  local status_var = (type or "metals") .. "_status"
+  local _status = "_status"
+  local metals = "metals"
+  local status_var = nil
+  if type and type == metals then
+    status_var = type .. _status
+  elseif type then
+    status_var = "metals_" .. type .. _status
+  else
+    status_var = metals .. _status
+  end
   vim.api.nvim_set_var(status_var, scaped_status)
 end
 

--- a/tests/tests/handlers/status_spec.lua
+++ b/tests/tests/handlers/status_spec.lua
@@ -22,6 +22,27 @@ describe("metals/status", function()
     local empty_status = vim.api.nvim_get_var("metals_status")
     assert.are.same("", empty_status)
   end)
+
+  it("correctly can set the bsp status", function()
+    local msg = "bsp message"
+    local metals_status = {
+      text = msg,
+      statusType = "bsp"
+    }
+    local ctx = {
+      client_id = "metals",
+      bufnr = "2",
+    }
+    handlers["metals/status"](nil, metals_status, ctx)
+    local first_status = vim.api.nvim_get_var("metals_bsp_status")
+    assert.are.same(msg, first_status)
+
+    metals_status.hide = true
+
+    handlers["metals/status"](nil, metals_status, ctx)
+    local empty_status = vim.api.nvim_get_var("metals_bsp_status")
+    assert.are.same("", empty_status)
+  end)
 end)
 
 describe("status.set_status", function()


### PR DESCRIPTION
We don't want to pollute the global namespace with this so instead of
using `bsp_status` we'll use `metals_bsp_status`.

CC @rochala .
