### PR TITLE
fix: make sure new lines are taken out of the short summary

### DIFF
--- a/lua/metals/doctor.lua
+++ b/lua/metals/doctor.lua
@@ -142,7 +142,10 @@ Doctor.create = function(args)
               table.insert(output, string.format("- error type: %s", report.errorReportType))
               table.insert(output, "")
               table.insert(output, "#### Summary")
-              table.insert(output, report.shortSummary)
+              local summary_lines = util.split_on(report.shortSummary, "\n")
+              for _, line in pairs(summary_lines) do
+                table.insert(output, line)
+              end
             end
           end
         end


### PR DESCRIPTION
In the new doctor short summary there is the potential to be new lines.
When adding things into the output of the doctor it was blowing up. This
ensures that these are stripped out and instead the multiple lines are
turned into a table and then added to the doctor output.
