### PR TITLE
fix: check for the existence of hoverMessage before using

### DIFF
--- a/lua/metals/decoration.lua
+++ b/lua/metals/decoration.lua
@@ -21,10 +21,12 @@ M.set_decoration = function(bufnr, decoration)
   local virt_text_opts = { virt_text = virt_texts, hl_mode = "combine" }
   local ext_id = api.nvim_buf_set_extmark(bufnr, M.decoration_namespace(), line, -1, virt_text_opts)
 
-  local hover_message = lsp.util.convert_input_to_markdown_lines(decoration.hoverMessage, {})
-  hover_message = lsp.util.trim_empty_lines(hover_message)
+  if decoration.hoverMessage then
+    local hover_message = lsp.util.convert_input_to_markdown_lines(decoration.hoverMessage, {})
+    hover_message = lsp.util.trim_empty_lines(hover_message)
 
-  hover_messages[ext_id] = hover_message
+    hover_messages[ext_id] = hover_message
+  end
 end
 
 M.hover_worksheet = function(opts)


### PR DESCRIPTION
In theory the way we use decorations (not being an inline decoration
provider) we shouldn't hit on this and never have. However
https://github.com/scalameta/metals/issues/5843 caused me to realize
that `hoverMessage` is optional and we shouldn't assume it will always
be there. This change checks the existence of it before actually trying
to store the message to display later.
