### PR TITLE
refactor: include a message when Test Explorer is not set for select commands

### DIFF
--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -508,11 +508,21 @@ M.toggle_setting = function(setting)
 end
 
 M.select_test_suite = function()
-  test_explorer.dap_select_test_suite()
+  local config = conf.get_config_cache()
+  if config and config.settings.metals.testUserInterface == "Test Explorer" then
+    test_explorer.dap_select_test_suite()
+  else
+    log.error_and_show(messages.enable_test_explorer)
+  end
 end
 
 M.select_test_case = function()
-  test_explorer.dap_select_test_case()
+  local config = conf.get_config_cache()
+  if config and config.settings.metals.testUserInterface == "Test Explorer" then
+    test_explorer.dap_select_test_case()
+  else
+    log.error_and_show(messages.enable_test_explorer)
+  end
 end
 
 M.open_new_github_issue = function()

--- a/lua/metals/messages.lua
+++ b/lua/metals/messages.lua
@@ -63,4 +63,7 @@ You recieved a null response for the tree view.
 If you're using Scala 3, this is expected as it's not support yet.
 If you're using Scala 2, please create an issue for this in nvim-metals.]]
 
+M.enable_test_explorer = [[
+You can't use this command unless you have "Test Explorer" set as the value of testUserInterface in your config.
+You can read more about this in :h metals-nvim-dap.]]
 return M


### PR DESCRIPTION
Currently even though the select test suite or case commands are always
available they won't actually work with Metals unless you have the Test
Explorer enabled. In order to keep discoverability of the commands I
still generate them no matter what, but if they user tries to use them,
they get a message about enabling the Test Explorer. In the past this
would just tell them, "hey, no tests", which wasn't accurate.
