### PR TITLE
fix: account for gradle.kts

### DIFF
--- a/lua/metals/config.lua
+++ b/lua/metals/config.lua
@@ -318,7 +318,7 @@ local function validate_config(config, bufnr)
   -- custom patters to be passed in without doing the entire root_dir logic
   -- yourself.
   config.root_patterns = config.root_patterns
-    or { "build.sbt", "build.sc", "build.gradle", "pom.xml", ".scala-build", "bleep.yaml", ".git" }
+    or { "build.sbt", "build.sc", "build.gradle", "build.gradle.kts", "pom.xml", ".scala-build", "bleep.yaml", ".git" }
 
   local bufname = api.nvim_buf_get_name(bufnr)
 


### PR DESCRIPTION
I realized that we only detected build.gradle in the past and not actually build.gradle.kts as a root pattern. This could cause nvim-metals not to correctly determine the root for gradle projects.

Closes #665