### PR TITLE
Log and show error if user_on_attach fails

### DIFF
--- a/lua/metals/config.lua
+++ b/lua/metals/config.lua
@@ -391,7 +391,10 @@ local function validate_config(config, bufnr)
   else
     local user_on_attach = config.on_attach
     config.on_attach = function(client, _bufnr)
-      user_on_attach(client, _bufnr)
+      local ok, res = pcall(user_on_attach, client, _bufnr)
+      if not ok then
+        log.error_and_show(string.format("Unexpected error when evaluating user's on_attach callback: '%s'", res))
+      end
       auto_commands()
     end
   end


### PR DESCRIPTION
I had an error in my `on_attach` function that was causing it to silently fail before any mappings where created. There was no info at all about the failure which made it harder to understand what is happening.

This PR logs any errors that could happen during the execution of user's `on_attach` callback.