### PR TITLE
feat: add inlay hints setting

### DIFF
--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -184,6 +184,7 @@ _ones that are sent and used by the server_
   * |excludedPackages|
   * |fallbackScalaVersion|
   * |gradleScript|
+  * |inlayHints|
   * |javaFormat.eclipseConfigPath|
   * |javaFormat.eclipseProfile|
   * |javaHome|
@@ -347,6 +348,21 @@ and Ammonite scripts.
 Note: Setting this to a higher version than Metals currently supports won't
 work and you'll just get a warning. So don't be cheeky and think you can bump
 faster than Metals can by using this.
+
+inlayHints                                                          *inlayHints*
+
+Type: table ~
+Default: {} ~
+
+Table of inlay hints to enable. >
+  {
+    hintsInPatternMatch = { enable = true },
+    implicitArguments = { enable = true },
+    implicitConversions = { enable = true },
+    inferredTypes = { enable = true },
+    typeParameters = { enable = true },
+  }
+<
 
 javaFormat.eclipseConfigPath                      *javaFormat.eclipseConfigPath*
 

--- a/doc/metals.txt
+++ b/doc/metals.txt
@@ -158,7 +158,7 @@ example below shows: >
 
   metals_config = require("metals").bare_config()
   metals_config.settings = {
-    showImplicitArguments = true,
+    verboseCompilation = true,
     excludedPackages = {
       "akka.actor.typed.javadsl",
       "com.github.swagger.akka.javadsl"
@@ -197,9 +197,6 @@ _ones that are sent and used by the server_
   * |scalafixRulesDependencies|
   * |scalafmtConfigPath|
   * |serverProperties|
-  * |showImplicitArguments|
-  * |showImplicitConversionsAndClasses|
-  * |showInferredType|
   * |superMethodLensesEnabled|
   * |verboseCompilation|
 
@@ -487,30 +484,6 @@ changed you need to do a |:MetalsInstall| or |:MetalsUpdate| again to ensure
 that it is installed. If you need to check what version you're currently
 using, you can use the |MetalsInfo| command. NOTE: that `latest.snapshot` is
 also available as a value to install whatever the latest snapshot is.
-
-showImplicitArguments                                    *showImplicitArguments*
-
-Type: boolean ~
-Default: false ~
-
-When this option is enabled, each method that has implicit arguments has them
-displayed as extra info in the hover.
-
-showImplicitConversionsAndClasses            *showImplicitConversionsAndClasses*
-
-Type: boolean ~
-Default: false ~
-
-When this option is enabled, each place where an implicit method or class is
-used has it displayed as extra info in the hover.
-
-showInferredType                                              *showInferredType*
-
-Type: boolean ~
-Default: false ~
-
-When this option is enabled, each method that can have inferred types has them
-displayed as extra info in the hover.
 
 serverProperties                                              *serverProperties*
 
@@ -1140,7 +1113,7 @@ toggle_setting({setting})
 
                            Example usage: >
 
-    lua require("metals").toggle_setting("showImplicitArguments")
+    lua require("metals").toggle_setting("verboseCompilation")
 <
 
                                                                 *type_of_range()*

--- a/lua/metals/config.lua
+++ b/lua/metals/config.lua
@@ -119,6 +119,7 @@ local valid_metals_settings = {
   "excludedPackages",
   "fallbackScalaVersion",
   "gradleScript",
+  "inlayHints",
   "javaFormat.eclipseConfigPath",
   "javaFormat.eclipseProfile",
   "javaHome",

--- a/tests/tests/config_spec.lua
+++ b/tests/tests/config_spec.lua
@@ -45,12 +45,12 @@ describe("config", function()
   it("should persist the config in cache", function()
     local bare_config = require("metals.setup").bare_config()
     bare_config.settings = {
-      showImplicitArguments = true,
+      verboseCompilation = true,
     }
 
     local valid_config = config.validate_config(bare_config, current_buf)
 
-    eq(valid_config.settings, { metals = { superMethodLensesEnabled = true, showImplicitArguments = true } })
+    eq(valid_config.settings, { metals = { superMethodLensesEnabled = true, verboseCompilation = true } })
 
     local cache = config.get_config_cache()
 


### PR DESCRIPTION
Add support for inlay hints settings introduced in Metals v1.3.0.

Reference:

- https://scalameta.org/metals/blog/2024/04/15/thalium#inlay-hints-support
- https://scalameta.org/metals/docs/editors/user-configuration