### PR TITLE
fix: make sure `make_range_params` works on nightly

### DIFF
--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -296,7 +296,7 @@ M.organize_imports = function()
   end
   local metals_client = lsp_clients[1]
 
-  local params = lsp.util.make_range_params()
+  local params = lsp.util.make_range_params(nil, "utf-8")
   params.context = { diagnostics = {}, only = { "source.organizeImports" } }
 
   local response = metals_client.request_sync("textDocument/codeAction", params, 1000, 0)


### PR DESCRIPTION
This should also be safe for the current stable release as it checks to
see if this exists before setting it.

closes #703
