### PR TITLE
Fix execute_command callback mechanism

### DIFF
--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -28,11 +28,10 @@ local M = {}
 local function execute_command(command_params, callback)
   lsp.buf_request_all(0, "workspace/executeCommand", command_params, function(responses)
     local metals_id = util.find_metals_client_id()
+    local response = responses[metals_id]
 
-    for client_id, response in pairs(responses) do
-      if client_id ~= metals_id then
-        return
-      elseif callback then
+    if response then
+      if callback then
         local context = response.ctx and response.ctx.method or ""
         callback(response.err, context, response)
       elseif response.err then


### PR DESCRIPTION
The `execute_command` function in `lua/metals.lua` has an issue, where it ignores the response from metals in some cases and never invokes the callback even if the response returned successfully. This occurres in those cases where metals is not the only LSP client attached to the buffer (Other one was copilot in my case), and the other client gets a smaller `client_id` than metals. The `buf_request_all` notifies all clients with the requested action and the other client's response comes before metals' so the for loop exits the whole response handling because the `client_id` mismatch. 

Possible solution is to check explicitly if metals has a response (with its `client_id`) and use it to invoke the callback.