### PR TITLE
Fix worksheet hover output not being in markdown

### DIFF
--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -493,8 +493,10 @@ M.hover_worksheet = function(opts)
   if evaluation_result then
     local tooltip = evaluation_result.inlay_hint.tooltip
 
-    local floating_preview_opts = util.check_exists_and_merge({ pad_left = 1, pad_right = 1 }, opts)
-    lsp.util.open_floating_preview({ "```scala", tooltip, "```" }, "markdown", floating_preview_opts)
+    if tooltip then
+      local floating_preview_opts = util.check_exists_and_merge({ pad_left = 1, pad_right = 1 }, opts)
+      lsp.util.open_floating_preview({ "```scala", tooltip, "```" }, "markdown", floating_preview_opts)
+    end
   end
 end
 

--- a/lua/metals.lua
+++ b/lua/metals.lua
@@ -494,7 +494,7 @@ M.hover_worksheet = function(opts)
     local tooltip = evaluation_result.inlay_hint.tooltip
 
     local floating_preview_opts = util.check_exists_and_merge({ pad_left = 1, pad_right = 1 }, opts)
-    lsp.util.open_floating_preview({ tooltip }, "markdown", floating_preview_opts)
+    lsp.util.open_floating_preview({ "```scala", tooltip, "```" }, "markdown", floating_preview_opts)
   end
 end
 


### PR DESCRIPTION
Hello!

I recently started using the new inlay hints feature for worksheets, and I noticed that the hover window's output looks a bit strange:
![image](https://github.com/user-attachments/assets/34bc04f5-4dae-4086-86f8-f25763bed9ef)

I noticed that even though the hover window's syntax is set to markdown, the result itself is not wrapped in backticks, so it's just displayed as plain text.
Wrapping it makes the result display in the same way as it used to:
![image](https://github.com/user-attachments/assets/e0c3b372-6a7a-4b2c-8066-ae4bd8b82af6)

I'm not that familiar with lua, so if this is not the most idiomatic way to do this, I'm open for suggestions. 😄 
