### PR TITLE
fix: ensure new snapshots can be downloaded

### DIFF
--- a/lua/metals/install.lua
+++ b/lua/metals/install.lua
@@ -66,6 +66,8 @@ local function create_args_for_install(server_org, binary_version, version)
     string.format("%s:metals_%s:%s", server_org, binary_version, version),
     "-r",
     "sonatype:snapshots",
+    "-r",
+    "https://central.sonatype.com/repository/maven-snapshots/",
     "-o",
     conf.metals_install_name(),
     "-f",


### PR DESCRIPTION
This make sure that the new snapshots can be downloaded since they are now published in a new place. See https://github.com/scalameta/metals/pull/7524 for reference.