### PR TITLE
fix: account for wrapped result

### DIFF
--- a/lua/metals/decoder.lua
+++ b/lua/metals/decoder.lua
@@ -88,7 +88,7 @@ local make_handler = function(decoder, format)
       log.error_and_show(string.format("Something went wrong trying to get %s. Please check the logs.", decoder))
       log.error(err)
     else
-      handle_decoder_response(result, decoder, format)
+      handle_decoder_response(result.result, decoder, format)
     end
   end
 end


### PR DESCRIPTION
I think this actually changed in the nvim side that this is wrapped in
an object now so we need to actually go in and get the result.

fixes #736
