### PR TITLE
Launch.json compatibility with VS Code's Metals

### DIFF
--- a/lua/metals/setup.lua
+++ b/lua/metals/setup.lua
@@ -111,12 +111,16 @@ local function setup_dap(execute_command)
       arguments = config.metals
     else
       local metals_dap_settings = config.metals or {}
+      local args = config.args or metals_dap_settings.args
+      local env = config.env or metals_dap_settings.env
+      local envFile = config.envFile or metals_dap_settings.envFile
+      local jvmOptions = config.jvmOptions or metals_dap_settings.jvmOptions
       arguments = {
         path = vim.uri_from_bufnr(0),
-        args = metals_dap_settings.args,
-        jvmOptions = metals_dap_settings.jvmOptions,
-        env = metals_dap_settings.env,
-        envFile = metals_dap_settings.envFile,
+        args = args,
+        jvmOptions = jvmOptions,
+        env = env,
+        envFile = envFile,
       }
       if metals_dap_settings.mainClass then
         arguments.mainClass = metals_dap_settings.mainClass


### PR DESCRIPTION
Hello guys, many thanks for a good experience for scala development using neovim.

According to documentation (https://scalameta.org/metals/docs/editors/vscode/#via-a-launchjson-configuration),  `jvmOptions` can be passed as parameter of original configuration object. 

Meanwhile, in nvim-metals `jvmOptions` needs to be inside `metals` object of configuration object.

My proposal remains compatibility with VSCode-based Metals configuration of `launch.json`.  
Also it will not break any existing `launch.json` files with config fields inside `metals` object.  

### Before:
```json
    {
      "type": "scala",
      "request": "launch",
      "name": "Launch Main",
      "mainClass": "Main",
      "args": [],
      "metals": {
        "jvmOptions": [],
        "envFile": "src/myenvs.env"
      }
    }
```

### After:
```json
    {
      "type": "scala",
      "request": "launch",
      "name": "Launch Main",
      "mainClass": "Main",
      "args": [],
      "jvmOptions": [],
      "envFile": "src/myenvs.env"
    }
```
